### PR TITLE
docs(workflow): document issue-to-pr flow and ignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ clawcrate-v3.1.1
 clawcrate-v3.1.1.md
 claude.md
 CLAUDE.md
+
+# Local-only files (do not commit)
+.github/pull_request_template.md
+.github/workflows/require-issue-closing-reference.yml
+error.log

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ cargo clippy --workspace -- -D warnings
 ```
 
 See [CLAUDE.md](CLAUDE.md) for the complete development guide with architecture decisions, coding standards, and step-by-step build instructions.
+See [docs/WORKFLOW.md](docs/WORKFLOW.md) for the operational issue-to-PR workflow used in this repository.
 
 ## License
 
@@ -310,4 +311,3 @@ MIT — see [LICENSE](LICENSE).
 <p align="center">
   <strong>Your agent runs free. Your secrets stay locked.</strong>
 </p>
-

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,123 @@
+# ClawCrate Development Workflow
+
+Este es el workflow operativo del repo para ejecutar backlog por issue sin perder trazabilidad.
+
+## 1. Sincronizar antes de empezar
+
+Desde `main`:
+
+```bash
+git fetch --all --prune
+git switch main
+git pull --ff-only
+git status -sb
+```
+
+Comprobar que `main` y `origin/main` apunten al mismo commit:
+
+```bash
+git rev-parse main origin/main
+```
+
+## 2. Elegir el siguiente issue del backlog
+
+- Fuente de verdad: `docs/backlog.yaml`
+- Issues en GitHub se ejecutan en orden del milestone actual.
+- Ejemplo de secuencia: `M1-04 -> M1-05 -> M1-06`
+
+## 3. Crear rama por issue
+
+Formato de rama:
+
+```text
+issue/mX-YY-descripcion-corta
+```
+
+Ejemplo:
+
+```bash
+git switch -c issue/m1-04-stack-auto-detection
+```
+
+## 4. Implementar solo el scope del issue
+
+- Evitar mezclar cambios no relacionados.
+- Mantener commits pequenos y alineados al backlog.
+
+## 5. Validar localmente antes de commit
+
+```bash
+cargo fmt --all
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+## 6. Commit con convencion
+
+Formato recomendado:
+
+```text
+<tipo>(mX-YY): <mensaje corto>
+```
+
+Ejemplos:
+
+- `feat(m1-04): implement stack auto-detection with safe fallback`
+- `test(m1-02): add serde roundtrip tests for core types`
+- `ci(m0-02): add baseline workflow for fmt clippy test check`
+
+## 7. Push y Pull Request
+
+```bash
+git push -u origin issue/m1-04-stack-auto-detection
+gh pr create --base main --head issue/m1-04-stack-auto-detection
+```
+
+Reglas del PR:
+
+- Titulo alineado al commit principal.
+- Body con resumen corto.
+- Incluir cierre automatico del issue:
+
+```text
+Closes #<issue-number>
+```
+
+Tambien valido: `Fixes #...` o `Resolves #...`.
+
+## 8. Cierre de issues
+
+### Automatico (recomendado)
+
+- Si el PR contiene `Closes/Fixes/Resolves #N`, GitHub cierra el issue al merge en `main`.
+
+### Manual (si aplica)
+
+```bash
+gh issue close <issue-number> --repo manuelpenazuniga/ClawCrate --comment "Done via PR #<pr-number>."
+```
+
+Cerrar un epic solo cuando todos sus child issues esten cerrados.
+
+## 9. Merge y post-merge
+
+Despues de mergear:
+
+```bash
+git switch main
+git fetch --all --prune
+git pull --ff-only
+git status -sb
+```
+
+Confirmar:
+
+- `main` sincronizado con `origin/main`
+- Issue cerrado en GitHub
+- Milestone actualizado correctamente
+
+## 10. Higiene de cambios
+
+- No commitear logs temporales ni archivos locales.
+- Si aparecen archivos locales recurrentes, agregarlos a `.gitignore`.
+- Mantener cada PR enfocado en un unico issue de backlog.


### PR DESCRIPTION
## Summary
Document the repository workflow in a persistent guide and link it from README. Also ignore local-only artifacts used during interactive sessions.

## Changes
- add docs/WORKFLOW.md with the operational backlog -> branch -> commit -> PR flow
- link workflow doc from README contributing section
- add local-only files to .gitignore

## Validation
- docs-only change
- no code behavior changes