### PR TITLE
feat(m1-05): implement env scrubbing and rlimit application modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -94,6 +106,8 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "clawcrate-profiles",
  "clawcrate-types",
+ "nix",
+ "thiserror",
 ]
 
 [[package]]
@@ -197,6 +211,18 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-traits"

--- a/crates/clawcrate-sandbox/Cargo.toml
+++ b/crates/clawcrate-sandbox/Cargo.toml
@@ -12,3 +12,5 @@ path = "src/lib.rs"
 [dependencies]
 clawcrate-profiles = { path = "../clawcrate-profiles" }
 clawcrate-types = { path = "../clawcrate-types" }
+nix = { version = "0.29", features = ["resource"] }
+thiserror = "2"

--- a/crates/clawcrate-sandbox/src/env_scrub.rs
+++ b/crates/clawcrate-sandbox/src/env_scrub.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScrubbedEnvironment {
+    pub kept: Vec<(String, String)>,
+    pub removed: Vec<String>,
+}
+
+pub fn scrub_current_environment(
+    scrub_patterns: &[String],
+    passthrough_patterns: &[String],
+) -> ScrubbedEnvironment {
+    scrub_environment(std::env::vars(), scrub_patterns, passthrough_patterns)
+}
+
+pub fn scrub_environment<I>(
+    vars: I,
+    scrub_patterns: &[String],
+    passthrough_patterns: &[String],
+) -> ScrubbedEnvironment
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut kept = Vec::new();
+    let mut removed = BTreeSet::new();
+
+    for (name, value) in vars {
+        let passes_passthrough = matches_any_pattern(&name, passthrough_patterns);
+        let should_scrub = matches_any_pattern(&name, scrub_patterns);
+        if should_scrub && !passes_passthrough {
+            removed.insert(name);
+            continue;
+        }
+        kept.push((name, value));
+    }
+
+    ScrubbedEnvironment {
+        kept,
+        removed: removed.into_iter().collect(),
+    }
+}
+
+fn matches_any_pattern(candidate: &str, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .filter(|pattern| !pattern.is_empty())
+        .any(|pattern| wildcard_matches(pattern, candidate))
+}
+
+fn wildcard_matches(pattern: &str, candidate: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+
+    let pattern_bytes = pattern.as_bytes();
+    let candidate_bytes = candidate.as_bytes();
+
+    let mut p = 0usize;
+    let mut c = 0usize;
+    let mut star_idx: Option<usize> = None;
+    let mut match_after_star = 0usize;
+
+    while c < candidate_bytes.len() {
+        if p < pattern_bytes.len() && pattern_bytes[p] == candidate_bytes[c] {
+            p += 1;
+            c += 1;
+            continue;
+        }
+
+        if p < pattern_bytes.len() && pattern_bytes[p] == b'*' {
+            star_idx = Some(p);
+            p += 1;
+            match_after_star = c;
+            continue;
+        }
+
+        if let Some(last_star_idx) = star_idx {
+            p = last_star_idx + 1;
+            match_after_star += 1;
+            c = match_after_star;
+            continue;
+        }
+
+        return false;
+    }
+
+    while p < pattern_bytes.len() && pattern_bytes[p] == b'*' {
+        p += 1;
+    }
+
+    p == pattern_bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{scrub_environment, wildcard_matches};
+
+    #[test]
+    fn removes_secret_variables_and_keeps_passthrough() {
+        let vars = vec![
+            ("AWS_SECRET_ACCESS_KEY".to_string(), "secret".to_string()),
+            ("HOME".to_string(), "/Users/test".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ];
+        let scrub_patterns = vec!["AWS_*".to_string(), "*_SECRET*".to_string()];
+        let passthrough_patterns = vec!["HOME".to_string(), "PATH".to_string()];
+
+        let scrubbed = scrub_environment(vars, &scrub_patterns, &passthrough_patterns);
+
+        assert_eq!(scrubbed.removed, vec!["AWS_SECRET_ACCESS_KEY".to_string()]);
+        assert!(scrubbed.kept.iter().any(|(name, _)| name == "HOME"));
+        assert!(scrubbed.kept.iter().any(|(name, _)| name == "PATH"));
+    }
+
+    #[test]
+    fn passthrough_pattern_overrides_scrub_pattern() {
+        let vars = vec![
+            ("NPM_TOKEN".to_string(), "token".to_string()),
+            ("GITHUB_TOKEN".to_string(), "token2".to_string()),
+        ];
+        let scrub_patterns = vec!["*_TOKEN*".to_string()];
+        let passthrough_patterns = vec!["NPM_*".to_string()];
+
+        let scrubbed = scrub_environment(vars, &scrub_patterns, &passthrough_patterns);
+
+        assert!(scrubbed.kept.iter().any(|(name, _)| name == "NPM_TOKEN"));
+        assert_eq!(scrubbed.removed, vec!["GITHUB_TOKEN".to_string()]);
+    }
+
+    #[test]
+    fn supports_wildcard_passthrough_patterns() {
+        let vars = vec![
+            ("LC_ALL".to_string(), "en_US.UTF-8".to_string()),
+            ("XDG_CACHE_HOME".to_string(), "/tmp/cache".to_string()),
+        ];
+        let scrub_patterns = vec!["LC_*".to_string(), "XDG_*".to_string()];
+        let passthrough_patterns = vec!["LC_*".to_string()];
+
+        let scrubbed = scrub_environment(vars, &scrub_patterns, &passthrough_patterns);
+
+        assert!(scrubbed.kept.iter().any(|(name, _)| name == "LC_ALL"));
+        assert_eq!(scrubbed.removed, vec!["XDG_CACHE_HOME".to_string()]);
+    }
+
+    #[test]
+    fn wildcard_matching_supports_infix_and_suffix_patterns() {
+        assert!(wildcard_matches("AWS_*", "AWS_SECRET_ACCESS_KEY"));
+        assert!(wildcard_matches("*_SECRET*", "AWS_SECRET_ACCESS_KEY"));
+        assert!(wildcard_matches("*_KEY", "DATABASE_KEY"));
+        assert!(!wildcard_matches("*_KEY", "DATABASE_KEY_EXTRA"));
+        assert!(!wildcard_matches("SSH_AUTH_SOCK", "SSH_AUTH"));
+    }
+}

--- a/crates/clawcrate-sandbox/src/lib.rs
+++ b/crates/clawcrate-sandbox/src/lib.rs
@@ -1,3 +1,6 @@
 #![forbid(unsafe_code)]
 
 pub const CRATE_NAME: &str = "clawcrate-sandbox";
+
+pub mod env_scrub;
+pub mod rlimits;

--- a/crates/clawcrate-sandbox/src/rlimits.rs
+++ b/crates/clawcrate-sandbox/src/rlimits.rs
@@ -1,0 +1,202 @@
+use clawcrate_types::ResourceLimits;
+use nix::sys::resource::{getrlimit, rlim_t, setrlimit, Resource, RLIM_INFINITY};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppliedRlimit {
+    pub resource: &'static str,
+    pub previous_soft: u64,
+    pub effective_soft: u64,
+    pub hard: u64,
+    pub changed: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RlimitError {
+    #[error("failed to query {resource}: {source}")]
+    Query {
+        resource: &'static str,
+        #[source]
+        source: nix::Error,
+    },
+    #[error("failed to apply {resource}: {source}")]
+    Apply {
+        resource: &'static str,
+        #[source]
+        source: nix::Error,
+    },
+}
+
+pub fn apply_resource_limits(limits: &ResourceLimits) -> Result<Vec<AppliedRlimit>, RlimitError> {
+    let targets = build_targets(limits);
+    let mut applied = Vec::with_capacity(targets.len());
+    for (resource, label, desired_soft) in targets {
+        applied.push(apply_soft_limit(resource, label, desired_soft)?);
+    }
+    Ok(applied)
+}
+
+fn build_targets(limits: &ResourceLimits) -> Vec<(Resource, &'static str, rlim_t)> {
+    let mut targets = vec![
+        (
+            Resource::RLIMIT_CPU,
+            "RLIMIT_CPU",
+            u64_to_rlim(limits.max_cpu_seconds),
+        ),
+        (
+            Resource::RLIMIT_AS,
+            "RLIMIT_AS",
+            u64_to_rlim(memory_mb_to_bytes(limits.max_memory_mb)),
+        ),
+        (
+            Resource::RLIMIT_NOFILE,
+            "RLIMIT_NOFILE",
+            u64_to_rlim(limits.max_open_files),
+        ),
+        (
+            Resource::RLIMIT_FSIZE,
+            "RLIMIT_FSIZE",
+            u64_to_rlim(limits.max_output_bytes),
+        ),
+    ];
+    push_process_limit_target(&mut targets, limits);
+    targets
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn push_process_limit_target(
+    targets: &mut Vec<(Resource, &'static str, rlim_t)>,
+    limits: &ResourceLimits,
+) {
+    targets.push((
+        Resource::RLIMIT_NPROC,
+        "RLIMIT_NPROC",
+        u64_to_rlim(limits.max_processes),
+    ));
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn push_process_limit_target(
+    _targets: &mut Vec<(Resource, &'static str, rlim_t)>,
+    _limits: &ResourceLimits,
+) {
+}
+
+fn apply_soft_limit(
+    resource: Resource,
+    label: &'static str,
+    desired_soft: rlim_t,
+) -> Result<AppliedRlimit, RlimitError> {
+    let (current_soft, current_hard) =
+        getrlimit(resource).map_err(|source| RlimitError::Query {
+            resource: label,
+            source,
+        })?;
+    let effective_soft = clamp_to_hard_limit(desired_soft, current_hard);
+    let changed = effective_soft != current_soft;
+    if changed {
+        setrlimit(resource, effective_soft, current_hard).map_err(|source| RlimitError::Apply {
+            resource: label,
+            source,
+        })?;
+    }
+
+    Ok(AppliedRlimit {
+        resource: label,
+        previous_soft: rlim_to_u64(current_soft),
+        effective_soft: rlim_to_u64(effective_soft),
+        hard: rlim_to_u64(current_hard),
+        changed,
+    })
+}
+
+fn clamp_to_hard_limit(desired_soft: rlim_t, hard: rlim_t) -> rlim_t {
+    if hard == RLIM_INFINITY {
+        desired_soft
+    } else {
+        desired_soft.min(hard)
+    }
+}
+
+fn memory_mb_to_bytes(memory_mb: u64) -> u64 {
+    memory_mb.saturating_mul(1024).saturating_mul(1024)
+}
+
+fn u64_to_rlim(value: u64) -> rlim_t {
+    rlim_t::try_from(value).unwrap_or(rlim_t::MAX)
+}
+
+fn rlim_to_u64(value: rlim_t) -> u64 {
+    let widened: u128 = value.into();
+    widened.min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_soft_limit, build_targets, clamp_to_hard_limit, memory_mb_to_bytes, u64_to_rlim,
+    };
+    use clawcrate_types::ResourceLimits;
+    use nix::sys::resource::{getrlimit, rlim_t, Resource, RLIM_INFINITY};
+
+    #[test]
+    fn maps_resource_limits_into_expected_targets() {
+        let limits = ResourceLimits {
+            max_cpu_seconds: 60,
+            max_memory_mb: 2048,
+            max_open_files: 1024,
+            max_processes: 128,
+            max_output_bytes: 1_048_576,
+        };
+
+        let targets = build_targets(&limits);
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        assert_eq!(targets.len(), 5);
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        assert_eq!(targets.len(), 4);
+        assert_eq!(targets[0].1, "RLIMIT_CPU");
+        assert_eq!(targets[0].2, u64_to_rlim(60));
+        assert_eq!(targets[1].1, "RLIMIT_AS");
+        assert_eq!(targets[1].2, u64_to_rlim(2_147_483_648));
+        assert_eq!(targets[2].1, "RLIMIT_NOFILE");
+        assert_eq!(targets[2].2, u64_to_rlim(1024));
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            assert_eq!(targets[3].1, "RLIMIT_FSIZE");
+            assert_eq!(targets[3].2, u64_to_rlim(1_048_576));
+            assert_eq!(targets[4].1, "RLIMIT_NPROC");
+            assert_eq!(targets[4].2, u64_to_rlim(128));
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            assert_eq!(targets[3].1, "RLIMIT_FSIZE");
+            assert_eq!(targets[3].2, u64_to_rlim(1_048_576));
+        }
+    }
+
+    #[test]
+    fn memory_conversion_is_saturating() {
+        assert_eq!(memory_mb_to_bytes(1), 1_048_576);
+        assert_eq!(memory_mb_to_bytes(u64::MAX), u64::MAX);
+    }
+
+    #[test]
+    fn clamp_respects_hard_limit() {
+        assert_eq!(clamp_to_hard_limit(200, 100), 100);
+        assert_eq!(clamp_to_hard_limit(50, 100), 50);
+        assert_eq!(clamp_to_hard_limit(50, RLIM_INFINITY), 50);
+    }
+
+    #[test]
+    fn apply_soft_limit_is_noop_when_desired_equals_current_soft_limit() {
+        let (soft, _) = getrlimit(Resource::RLIMIT_NOFILE).expect("query RLIMIT_NOFILE");
+        let applied = apply_soft_limit(Resource::RLIMIT_NOFILE, "RLIMIT_NOFILE", soft)
+            .expect("apply RLIMIT_NOFILE");
+        assert!(!applied.changed);
+        assert_eq!(applied.previous_soft, applied.effective_soft);
+    }
+
+    #[test]
+    fn u64_to_rlim_clamps_to_target_type_max() {
+        assert_eq!(u64_to_rlim(u64::MAX), rlim_t::MAX);
+    }
+}


### PR DESCRIPTION
## Summary
Implement M1-05 in clawcrate-sandbox with two new modules:
- environment scrubbing based on wildcard scrub/passthrough patterns
- cross-platform rlimit application from ResourceLimits using setrlimit (best-effort per platform)

## Backlog Link
Closes #17

## Validation
- [x] cargo fmt --all
- [x] cargo test -p clawcrate-sandbox
- [x] cargo test --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
