### PR TITLE
feat(m1-06): implement plan command with human and json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +122,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clawcrate-audit"
 version = "0.1.0-alpha.0"
 dependencies = [
@@ -83,11 +179,17 @@ dependencies = [
 name = "clawcrate-cli"
 version = "0.1.0-alpha.0"
 dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
  "clawcrate-audit",
  "clawcrate-capture",
  "clawcrate-profiles",
  "clawcrate-sandbox",
  "clawcrate-types",
+ "comfy-table",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -121,10 +223,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "equivalent"
@@ -133,16 +284,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -169,14 +364,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -195,10 +404,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -240,6 +476,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +533,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +571,18 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -332,6 +647,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,10 +696,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -418,6 +798,62 @@ checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -476,6 +912,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/crates/clawcrate-cli/Cargo.toml
+++ b/crates/clawcrate-cli/Cargo.toml
@@ -11,8 +11,14 @@ name = "clawcrate"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
 clawcrate-audit = { path = "../clawcrate-audit" }
 clawcrate-capture = { path = "../clawcrate-capture" }
 clawcrate-profiles = { path = "../clawcrate-profiles" }
 clawcrate-sandbox = { path = "../clawcrate-sandbox" }
 clawcrate-types = { path = "../clawcrate-types" }
+clap = { version = "4", features = ["derive"] }
+comfy-table = "7"
+serde_json = "1"
+uuid = { version = "1", features = ["v7"] }

--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -1,5 +1,305 @@
 #![forbid(unsafe_code)]
 
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use clap::{ArgAction, Args, Parser, Subcommand};
+use clawcrate_profiles::ProfileResolver;
+use clawcrate_types::{Actor, DefaultMode, ExecutionPlan, WorkspaceMode};
+use comfy_table::{Cell, Table};
+use uuid::Uuid;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "clawcrate",
+    version,
+    about = "Secure execution runtime for AI shell commands"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Execute a command inside a sandbox
+    Run(CommandArgs),
+    /// Show execution plan without executing (dry-run)
+    Plan(CommandArgs),
+    /// Check system sandboxing capabilities
+    Doctor(DoctorArgs),
+}
+
+#[derive(Debug, Args)]
+struct CommandArgs {
+    /// Built-in profile name (safe/build/install/open) or YAML file path
+    #[arg(long)]
+    profile: Option<String>,
+
+    /// Force replica mode
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "direct")]
+    replica: bool,
+
+    /// Force direct mode
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "replica")]
+    direct: bool,
+
+    /// Machine-readable JSON output
+    #[arg(long, action = ArgAction::SetTrue)]
+    json: bool,
+
+    /// Command to plan/execute (pass after --)
+    #[arg(trailing_var_arg = true, num_args = 1.., required = true)]
+    command: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+struct DoctorArgs {
+    /// Machine-readable JSON output
+    #[arg(long, action = ArgAction::SetTrue)]
+    json: bool,
+}
+
 fn main() {
-    println!("clawcrate scaffold initialized");
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+    let resolver = ProfileResolver::default();
+
+    match cli.command {
+        Commands::Plan(args) => handle_plan(&resolver, args),
+        Commands::Run(_) => Err(anyhow!(
+            "`run` is not implemented yet. Use `clawcrate plan -- ...` for now."
+        )),
+        Commands::Doctor(_) => Err(anyhow!(
+            "`doctor` is not implemented yet. Use `clawcrate plan -- ...` for now."
+        )),
+    }
+}
+
+fn handle_plan(resolver: &ProfileResolver, args: CommandArgs) -> Result<()> {
+    let cwd =
+        std::env::current_dir().map_err(|source| anyhow!("failed to get current dir: {source}"))?;
+    let plan = build_execution_plan(resolver, &cwd, &args)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&plan)?);
+    } else {
+        print_human_plan(&plan);
+    }
+
+    Ok(())
+}
+
+fn build_execution_plan(
+    resolver: &ProfileResolver,
+    cwd: &Path,
+    args: &CommandArgs,
+) -> Result<ExecutionPlan> {
+    let profile = match args.profile.as_deref() {
+        Some(explicit) => resolver.resolve(explicit),
+        None => resolver.resolve_auto(cwd),
+    }
+    .map_err(|source| anyhow!("failed to resolve profile: {source}"))?;
+
+    let effective_default_mode = select_default_mode(profile.default_mode.clone(), args);
+    let execution_id = Uuid::now_v7().to_string();
+    let mode = materialize_workspace_mode(cwd, effective_default_mode, &execution_id);
+    let execution_cwd = match &mode {
+        WorkspaceMode::Direct => cwd.to_path_buf(),
+        WorkspaceMode::Replica { copy, .. } => copy.clone(),
+    };
+
+    Ok(ExecutionPlan {
+        id: execution_id,
+        command: args.command.clone(),
+        cwd: execution_cwd,
+        profile,
+        mode,
+        actor: Actor::Human,
+        created_at: Utc::now(),
+    })
+}
+
+fn select_default_mode(default_mode: DefaultMode, args: &CommandArgs) -> DefaultMode {
+    if args.replica {
+        DefaultMode::Replica
+    } else if args.direct {
+        DefaultMode::Direct
+    } else {
+        default_mode
+    }
+}
+
+fn materialize_workspace_mode(
+    source_cwd: &Path,
+    effective_mode: DefaultMode,
+    execution_id: &str,
+) -> WorkspaceMode {
+    match effective_mode {
+        DefaultMode::Direct => WorkspaceMode::Direct,
+        DefaultMode::Replica => WorkspaceMode::Replica {
+            source: source_cwd.to_path_buf(),
+            copy: std::env::temp_dir()
+                .join("clawcrate")
+                .join(format!("exec_{execution_id}"))
+                .join("workspace"),
+        },
+    }
+}
+
+fn print_human_plan(plan: &ExecutionPlan) {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["Field", "Value"])
+        .add_row(vec![Cell::new("Execution ID"), Cell::new(&plan.id)])
+        .add_row(vec![Cell::new("Profile"), Cell::new(&plan.profile.name)])
+        .add_row(vec![
+            Cell::new("Workspace Mode"),
+            Cell::new(match plan.mode {
+                WorkspaceMode::Direct => "Direct",
+                WorkspaceMode::Replica { .. } => "Replica",
+            }),
+        ])
+        .add_row(vec![
+            Cell::new("Command"),
+            Cell::new(plan.command.join(" ")),
+        ])
+        .add_row(vec![
+            Cell::new("Execution CWD"),
+            Cell::new(plan.cwd.display().to_string()),
+        ])
+        .add_row(vec![
+            Cell::new("Network"),
+            Cell::new(match plan.profile.net {
+                clawcrate_types::NetLevel::None => "none",
+                clawcrate_types::NetLevel::Open => "open",
+            }),
+        ])
+        .add_row(vec![
+            Cell::new("Filesystem Read Paths"),
+            Cell::new(plan.profile.fs_read.len().to_string()),
+        ])
+        .add_row(vec![
+            Cell::new("Filesystem Write Paths"),
+            Cell::new(plan.profile.fs_write.len().to_string()),
+        ])
+        .add_row(vec![
+            Cell::new("Env Scrub Patterns"),
+            Cell::new(plan.profile.env_scrub.len().to_string()),
+        ]);
+
+    println!("{table}");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{build_execution_plan, select_default_mode, CommandArgs};
+    use clap::Parser;
+    use clawcrate_profiles::ProfileResolver;
+    use clawcrate_types::{DefaultMode, WorkspaceMode};
+
+    fn unique_tmp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}_{nanos}_{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("create temp test directory");
+        dir
+    }
+
+    #[test]
+    fn parses_plan_command_with_profile_and_command() {
+        let cli = super::Cli::parse_from([
+            "clawcrate",
+            "plan",
+            "--profile",
+            "build",
+            "--",
+            "cargo",
+            "test",
+        ]);
+
+        match cli.command {
+            super::Commands::Plan(args) => {
+                assert_eq!(args.profile.as_deref(), Some("build"));
+                assert_eq!(args.command, vec!["cargo".to_string(), "test".to_string()]);
+                assert!(!args.json);
+            }
+            _ => panic!("expected plan command"),
+        }
+    }
+
+    #[test]
+    fn profile_default_mode_is_overridden_by_flags() {
+        let args = CommandArgs {
+            profile: None,
+            replica: true,
+            direct: false,
+            json: false,
+            command: vec!["echo".to_string(), "hello".to_string()],
+        };
+        assert_eq!(
+            select_default_mode(DefaultMode::Direct, &args),
+            DefaultMode::Replica
+        );
+    }
+
+    #[test]
+    fn auto_detect_falls_back_to_safe_when_workspace_is_unknown() {
+        let resolver = ProfileResolver::default();
+        let cwd = unique_tmp_dir("clawcrate_cli_plan_safe");
+        let args = CommandArgs {
+            profile: None,
+            replica: false,
+            direct: false,
+            json: false,
+            command: vec!["echo".to_string(), "hello".to_string()],
+        };
+
+        let plan = build_execution_plan(&resolver, &cwd, &args).expect("build execution plan");
+        assert_eq!(plan.profile.name, "safe");
+        assert!(matches!(plan.mode, WorkspaceMode::Direct));
+        assert_eq!(plan.cwd, cwd);
+    }
+
+    #[test]
+    fn install_profile_materializes_replica_mode() {
+        let resolver = ProfileResolver::default();
+        let cwd = unique_tmp_dir("clawcrate_cli_plan_replica");
+        fs::write(
+            cwd.join("package.json"),
+            "{ \"name\": \"demo\", \"version\": \"0.1.0\" }",
+        )
+        .expect("write package json");
+
+        let args = CommandArgs {
+            profile: Some("install".to_string()),
+            replica: false,
+            direct: false,
+            json: false,
+            command: vec!["npm".to_string(), "install".to_string()],
+        };
+
+        let plan = build_execution_plan(&resolver, &cwd, &args).expect("build execution plan");
+        match &plan.mode {
+            WorkspaceMode::Replica { source, copy } => {
+                assert_eq!(source, &cwd);
+                assert!(copy.starts_with(Path::new(&std::env::temp_dir())));
+                assert_eq!(plan.cwd, *copy);
+            }
+            WorkspaceMode::Direct => panic!("install profile must default to replica"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Implement `clawcrate plan` with profile resolution wiring and dual output modes (human table + JSON).

## What was added
- clap-based CLI with subcommands: run, plan, doctor (plan implemented now)
- plan argument parsing with --profile, --replica/--direct, --json, and command passthrough
- auto profile resolution via resolver.resolve_auto when no --profile is provided
- DefaultMode to WorkspaceMode materialization for plan output
- human-readable plan table + pretty JSON output
- unit tests for parsing, auto-fallback, and replica materialization

## Backlog Link
Closes #18

## Validation
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace
