### PR TITLE
feat(m2-05): wire doctor command to platform capability probes

### DIFF
--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -6,7 +6,13 @@ use anyhow::{anyhow, Result};
 use chrono::Utc;
 use clap::{ArgAction, Args, Parser, Subcommand};
 use clawcrate_profiles::ProfileResolver;
-use clawcrate_types::{Actor, DefaultMode, ExecutionPlan, WorkspaceMode};
+#[cfg(target_os = "linux")]
+use clawcrate_sandbox::linux_probe::probe_linux_capabilities;
+#[cfg(target_os = "macos")]
+use clawcrate_sandbox::macos_probe::probe_macos_capabilities;
+use clawcrate_types::{
+    Actor, DefaultMode, ExecutionPlan, Platform, SystemCapabilities, WorkspaceMode,
+};
 use comfy_table::{Cell, Table};
 use uuid::Uuid;
 
@@ -77,9 +83,7 @@ fn run() -> Result<()> {
         Commands::Run(_) => Err(anyhow!(
             "`run` is not implemented yet. Use `clawcrate plan -- ...` for now."
         )),
-        Commands::Doctor(_) => Err(anyhow!(
-            "`doctor` is not implemented yet. Use `clawcrate plan -- ...` for now."
-        )),
+        Commands::Doctor(args) => handle_doctor(args),
     }
 }
 
@@ -154,6 +158,112 @@ fn materialize_workspace_mode(
     }
 }
 
+fn handle_doctor(args: DoctorArgs) -> Result<()> {
+    let capabilities = probe_system_capabilities()?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&capabilities)?);
+    } else {
+        print_human_doctor(&capabilities);
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn probe_system_capabilities() -> Result<SystemCapabilities> {
+    Ok(probe_linux_capabilities())
+}
+
+#[cfg(target_os = "macos")]
+fn probe_system_capabilities() -> Result<SystemCapabilities> {
+    Ok(probe_macos_capabilities())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn probe_system_capabilities() -> Result<SystemCapabilities> {
+    Err(anyhow!("unsupported platform for `doctor` command"))
+}
+
+fn print_human_doctor(capabilities: &SystemCapabilities) {
+    let mut table = Table::new();
+    table.set_header(vec!["Capability", "Status"]);
+    for (name, status) in doctor_rows(capabilities) {
+        table.add_row(vec![Cell::new(name), Cell::new(status)]);
+    }
+    println!("{table}");
+}
+
+fn doctor_rows(capabilities: &SystemCapabilities) -> Vec<(String, String)> {
+    let kernel_version = capabilities
+        .kernel_version
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let macos_version = if capabilities.platform == Platform::MacOS {
+        capabilities
+            .macos_version
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string())
+    } else {
+        "n/a".to_string()
+    };
+
+    let landlock_status = if capabilities.platform == Platform::Linux {
+        capabilities
+            .landlock_abi
+            .map(|abi| format!("✅ ABI {abi}"))
+            .unwrap_or_else(|| "❌ unavailable".to_string())
+    } else {
+        "n/a".to_string()
+    };
+
+    let seccomp_status = if capabilities.platform == Platform::Linux {
+        bool_status(capabilities.seccomp_available)
+    } else {
+        "n/a".to_string()
+    };
+
+    let seatbelt_status = if capabilities.platform == Platform::MacOS {
+        bool_status(capabilities.seatbelt_available)
+    } else {
+        "n/a".to_string()
+    };
+
+    let user_namespaces_status = if capabilities.platform == Platform::Linux {
+        bool_status(capabilities.user_namespaces)
+    } else {
+        "n/a".to_string()
+    };
+
+    vec![
+        (
+            "Platform".to_string(),
+            platform_label(&capabilities.platform),
+        ),
+        ("Kernel Version".to_string(), kernel_version),
+        ("macOS Version".to_string(), macos_version),
+        ("Landlock ABI".to_string(), landlock_status),
+        ("seccomp".to_string(), seccomp_status),
+        ("Seatbelt".to_string(), seatbelt_status),
+        ("User Namespaces".to_string(), user_namespaces_status),
+    ]
+}
+
+fn bool_status(enabled: bool) -> String {
+    if enabled {
+        "✅ available".to_string()
+    } else {
+        "❌ unavailable".to_string()
+    }
+}
+
+fn platform_label(platform: &Platform) -> String {
+    match platform {
+        Platform::Linux => "Linux".to_string(),
+        Platform::MacOS => "macOS".to_string(),
+    }
+}
+
 fn print_human_plan(plan: &ExecutionPlan) {
     let mut table = Table::new();
     table
@@ -204,10 +314,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{build_execution_plan, select_default_mode, CommandArgs};
+    use super::{build_execution_plan, doctor_rows, select_default_mode, CommandArgs};
     use clap::Parser;
     use clawcrate_profiles::ProfileResolver;
-    use clawcrate_types::{DefaultMode, WorkspaceMode};
+    use clawcrate_types::{DefaultMode, Platform, SystemCapabilities, WorkspaceMode};
 
     fn unique_tmp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -238,6 +348,16 @@ mod tests {
                 assert!(!args.json);
             }
             _ => panic!("expected plan command"),
+        }
+    }
+
+    #[test]
+    fn parses_doctor_command_with_json() {
+        let cli = super::Cli::parse_from(["clawcrate", "doctor", "--json"]);
+
+        match cli.command {
+            super::Commands::Doctor(args) => assert!(args.json),
+            _ => panic!("expected doctor command"),
         }
     }
 
@@ -301,5 +421,59 @@ mod tests {
             }
             WorkspaceMode::Direct => panic!("install profile must default to replica"),
         }
+    }
+
+    #[test]
+    fn doctor_rows_render_linux_specific_capabilities() {
+        let capabilities = SystemCapabilities {
+            platform: Platform::Linux,
+            landlock_abi: Some(4),
+            seccomp_available: true,
+            seatbelt_available: false,
+            user_namespaces: true,
+            macos_version: None,
+            kernel_version: Some("6.8.12".to_string()),
+        };
+
+        let rows = doctor_rows(&capabilities);
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "Platform" && value == "Linux"));
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "Landlock ABI" && value == "✅ ABI 4"));
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "seccomp" && value == "✅ available"));
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "Seatbelt" && value == "n/a"));
+    }
+
+    #[test]
+    fn doctor_rows_render_macos_specific_capabilities() {
+        let capabilities = SystemCapabilities {
+            platform: Platform::MacOS,
+            landlock_abi: None,
+            seccomp_available: false,
+            seatbelt_available: true,
+            user_namespaces: false,
+            macos_version: Some("14.5".to_string()),
+            kernel_version: Some("23.5.0".to_string()),
+        };
+
+        let rows = doctor_rows(&capabilities);
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "Platform" && value == "macOS"));
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "macOS Version" && value == "14.5"));
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "Seatbelt" && value == "✅ available"));
+        assert!(rows
+            .iter()
+            .any(|(name, value)| name == "Landlock ABI" && value == "n/a"));
     }
 }


### PR DESCRIPTION
Summary
- implement doctor command wiring in clawcrate-cli
- probe capabilities through platform-specific sandbox backends (linux and macOS)
- add human-readable doctor table output plus JSON output support
- include unit tests for doctor command parsing and capability row rendering

Validation
- cargo fmt --all
- cargo test -p clawcrate-cli
- cargo clippy -p clawcrate-cli --all-targets -- -D warnings
- cargo run -p clawcrate-cli -- doctor --json

Closes #23