### PR TITLE
feat(m3-02): implement filesystem snapshot and diff engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,7 +182,9 @@ name = "clawcrate-capture"
 version = "0.1.0-alpha.0"
 dependencies = [
  "clawcrate-types",
+ "sha2",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -248,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +288,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -306,6 +346,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -575,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +812,22 @@ dependencies = [
  "getrandom",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -850,6 +942,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/clawcrate-capture/Cargo.toml
+++ b/crates/clawcrate-capture/Cargo.toml
@@ -11,4 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 clawcrate-types = { path = "../clawcrate-types" }
+sha2 = "0.10"
 thiserror = "2"
+walkdir = "2"

--- a/crates/clawcrate-capture/src/lib.rs
+++ b/crates/clawcrate-capture/src/lib.rs
@@ -1,11 +1,16 @@
 #![forbid(unsafe_code)]
 
+use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdout, ExitStatus};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::UNIX_EPOCH;
+
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
 
 pub const CRATE_NAME: &str = "clawcrate-capture";
 
@@ -71,6 +76,32 @@ pub struct CapturedChildOutput {
     pub summary: CaptureSummary,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileFingerprint {
+    pub size_bytes: u64,
+    pub modified_unix_nanos: u128,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSnapshot {
+    pub entries: BTreeMap<PathBuf, FileFingerprint>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsChangeKind {
+    Created,
+    Modified,
+    Deleted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FsChange {
+    pub path: PathBuf,
+    pub kind: FsChangeKind,
+    pub size_bytes: Option<u64>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum CaptureError {
     #[error("failed to create artifacts directory: {0}")]
@@ -96,6 +127,18 @@ pub enum CaptureError {
     ThreadPanic,
     #[error("failed to wait for child process: {0}")]
     WaitChild(#[source] io::Error),
+    #[error("failed to walk snapshot root {root}: {source}")]
+    SnapshotWalk {
+        root: PathBuf,
+        #[source]
+        source: walkdir::Error,
+    },
+    #[error("filesystem snapshot IO failed for {path}: {source}")]
+    SnapshotIo {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
 }
 
 #[derive(Debug)]
@@ -250,6 +293,119 @@ fn join_capture_thread(
     }
 }
 
+pub fn snapshot_paths(paths: &[PathBuf]) -> Result<FileSnapshot, CaptureError> {
+    let mut entries = BTreeMap::new();
+
+    for root in paths {
+        if !root.exists() {
+            continue;
+        }
+
+        if root.is_file() {
+            let fingerprint = fingerprint_path(root)?;
+            entries.insert(root.clone(), fingerprint);
+            continue;
+        }
+
+        for walk_entry in WalkDir::new(root).follow_links(false) {
+            let walk_entry = walk_entry.map_err(|source| CaptureError::SnapshotWalk {
+                root: root.clone(),
+                source,
+            })?;
+
+            if !walk_entry.file_type().is_file() {
+                continue;
+            }
+
+            let path = walk_entry.path().to_path_buf();
+            let fingerprint = fingerprint_path(&path)?;
+            entries.insert(path, fingerprint);
+        }
+    }
+
+    Ok(FileSnapshot { entries })
+}
+
+pub fn diff_snapshots(before: &FileSnapshot, after: &FileSnapshot) -> Vec<FsChange> {
+    let mut changes = Vec::new();
+
+    for (path, before_fingerprint) in &before.entries {
+        match after.entries.get(path) {
+            None => changes.push(FsChange {
+                path: path.clone(),
+                kind: FsChangeKind::Deleted,
+                size_bytes: Some(before_fingerprint.size_bytes),
+            }),
+            Some(after_fingerprint) if after_fingerprint != before_fingerprint => {
+                changes.push(FsChange {
+                    path: path.clone(),
+                    kind: FsChangeKind::Modified,
+                    size_bytes: Some(after_fingerprint.size_bytes),
+                });
+            }
+            Some(_) => {}
+        }
+    }
+
+    for (path, after_fingerprint) in &after.entries {
+        if !before.entries.contains_key(path) {
+            changes.push(FsChange {
+                path: path.clone(),
+                kind: FsChangeKind::Created,
+                size_bytes: Some(after_fingerprint.size_bytes),
+            });
+        }
+    }
+
+    changes.sort_by(|left, right| left.path.cmp(&right.path));
+    changes
+}
+
+fn fingerprint_path(path: &Path) -> Result<FileFingerprint, CaptureError> {
+    let metadata = fs::metadata(path).map_err(|source| CaptureError::SnapshotIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let modified_unix_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let sha256 = hash_sha256(path)?;
+
+    Ok(FileFingerprint {
+        size_bytes: metadata.len(),
+        modified_unix_nanos,
+        sha256,
+    })
+}
+
+fn hash_sha256(path: &Path) -> Result<String, CaptureError> {
+    let mut file = File::open(path).map_err(|source| CaptureError::SnapshotIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; READ_CHUNK_SIZE];
+
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|source| CaptureError::SnapshotIo {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    let digest = hasher.finalize();
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -258,7 +414,10 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{capture_child_output, capture_streams, CaptureConfig};
+    use super::{
+        capture_child_output, capture_streams, diff_snapshots, snapshot_paths, CaptureConfig,
+        FsChangeKind,
+    };
 
     fn unique_tmp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -353,5 +512,71 @@ mod tests {
             fs::read_to_string(config.stderr_log_path()).expect("read stderr log"),
             "hello-err"
         );
+    }
+
+    #[test]
+    fn snapshot_paths_captures_nested_files_with_hashes() {
+        let tmp = unique_tmp_dir("clawcrate_snapshot_nested");
+        let nested = tmp.join("workspace").join("src");
+        fs::create_dir_all(&nested).expect("create nested directory");
+        fs::write(tmp.join("workspace").join("root.txt"), "root").expect("write root file");
+        fs::write(nested.join("lib.rs"), "fn main() {}").expect("write nested file");
+
+        let snapshot = snapshot_paths(&[tmp.join("workspace")]).expect("snapshot paths");
+        assert_eq!(snapshot.entries.len(), 2);
+        for fingerprint in snapshot.entries.values() {
+            assert_eq!(fingerprint.sha256.len(), 64);
+            assert!(fingerprint.size_bytes > 0);
+        }
+    }
+
+    #[test]
+    fn diff_snapshots_detects_created_modified_and_deleted() {
+        let tmp = unique_tmp_dir("clawcrate_snapshot_diff");
+        let root = tmp.join("workspace");
+        fs::create_dir_all(&root).expect("create workspace");
+
+        let stable = root.join("stable.txt");
+        let modified = root.join("modified.txt");
+        let deleted = root.join("deleted.txt");
+        let created = root.join("created.txt");
+
+        fs::write(&stable, "same").expect("write stable");
+        fs::write(&modified, "before").expect("write modified before");
+        fs::write(&deleted, "remove me").expect("write deleted");
+
+        let before = snapshot_paths(std::slice::from_ref(&root)).expect("snapshot before");
+
+        fs::write(&modified, "after").expect("write modified after");
+        fs::remove_file(&deleted).expect("delete file");
+        fs::write(&created, "new").expect("write created");
+
+        let after = snapshot_paths(&[root]).expect("snapshot after");
+        let diff = diff_snapshots(&before, &after);
+
+        assert!(diff
+            .iter()
+            .any(|change| change.path == modified && change.kind == FsChangeKind::Modified));
+        assert!(diff
+            .iter()
+            .any(|change| change.path == deleted && change.kind == FsChangeKind::Deleted));
+        assert!(diff
+            .iter()
+            .any(|change| change.path == created && change.kind == FsChangeKind::Created));
+        assert!(!diff
+            .iter()
+            .any(|change| change.path == stable && change.kind != FsChangeKind::Modified));
+    }
+
+    #[test]
+    fn snapshot_paths_ignores_missing_roots_and_preserves_existing_ones() {
+        let tmp = unique_tmp_dir("clawcrate_snapshot_missing");
+        let existing = tmp.join("existing");
+        let missing = tmp.join("missing");
+        fs::create_dir_all(&existing).expect("create existing directory");
+        fs::write(existing.join("a.txt"), "a").expect("write existing file");
+
+        let snapshot = snapshot_paths(&[missing, existing]).expect("snapshot with missing root");
+        assert_eq!(snapshot.entries.len(), 1);
     }
 }


### PR DESCRIPTION
Summary
- add filesystem snapshot engine in clawcrate-capture using recursive path walking
- fingerprint files with size, modified timestamp, and SHA-256 digest
- add snapshot diff classification for Created, Modified, and Deleted changes
- keep snapshot behavior resilient by skipping missing roots
- add unit tests for nested snapshots, diff classification, and missing-root handling

Validation
- cargo fmt --all
- cargo test -p clawcrate-capture
- cargo clippy -p clawcrate-capture --all-targets -- -D warnings

Closes #26