### PR TITLE
feat: implement .clawcrateignore parser and matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -205,6 +224,7 @@ dependencies = [
  "clawcrate-sandbox",
  "clawcrate-types",
  "comfy-table",
+ "ignore",
  "nix",
  "serde",
  "serde_json",
@@ -274,6 +294,31 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -379,6 +424,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +486,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -606,6 +680,23 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ clawcrate run --replica --profile build -- cargo test
 clawcrate run --direct --profile install -- npm install
 ```
 
-Current default exclusions in replica copy: `.env`, `.env.*`, `.git/config`.
+Replica copy exclusions: default `.env`, `.env.*`, `.git/config`, plus any rules in `.clawcrateignore`.
 
 **Syncing changes back always requires explicit confirmation. It never happens automatically.**
 

--- a/crates/clawcrate-cli/Cargo.toml
+++ b/crates/clawcrate-cli/Cargo.toml
@@ -20,6 +20,7 @@ clawcrate-sandbox = { path = "../clawcrate-sandbox" }
 clawcrate-types = { path = "../clawcrate-types" }
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
+ignore = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v7"] }

--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -27,6 +27,7 @@ use clawcrate_types::{
     Status, SystemCapabilities, WorkspaceMode,
 };
 use comfy_table::{Cell, Table};
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 #[cfg(unix)]
 use nix::errno::Errno;
 #[cfg(unix)]
@@ -256,6 +257,12 @@ fn execute_run_pipeline(
 
 const REPLICA_DEFAULT_EXCLUSIONS: [&str; 3] = [".env", ".env.*", ".git/config"];
 
+#[derive(Debug)]
+struct ReplicaIgnoreConfig {
+    matcher: Gitignore,
+    user_patterns: Vec<String>,
+}
+
 fn materialize_workspace_for_execution(
     plan: &ExecutionPlan,
     writer: &ArtifactWriter,
@@ -264,22 +271,71 @@ fn materialize_workspace_for_execution(
         return Ok(());
     };
 
-    copy_workspace_with_default_exclusions(source, copy)?;
+    let ignore_config = load_replica_ignore_config(source)?;
+    copy_workspace_with_default_exclusions(source, copy, &ignore_config)?;
+    let mut excluded = REPLICA_DEFAULT_EXCLUSIONS
+        .iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>();
+    excluded.extend(ignore_config.user_patterns);
     append_audit_event(
         writer,
         AuditEventKind::ReplicaCreated {
             source: source.clone(),
             copy: copy.clone(),
-            excluded: REPLICA_DEFAULT_EXCLUSIONS
-                .iter()
-                .map(|value| value.to_string())
-                .collect(),
+            excluded,
         },
     )?;
     Ok(())
 }
 
-fn copy_workspace_with_default_exclusions(source: &Path, copy: &Path) -> Result<()> {
+fn load_replica_ignore_config(source_root: &Path) -> Result<ReplicaIgnoreConfig> {
+    let ignore_path = source_root.join(".clawcrateignore");
+    let user_patterns = load_user_ignore_patterns(&ignore_path)?;
+
+    let mut builder = GitignoreBuilder::new(source_root);
+    if ignore_path.is_file() {
+        if let Some(source) = builder.add(&ignore_path) {
+            return Err(anyhow!(
+                "failed to parse {}: {source}",
+                ignore_path.display()
+            ));
+        }
+    }
+
+    let matcher = builder.build().map_err(|source| {
+        anyhow!(
+            "failed to build .clawcrateignore matcher from {}: {source}",
+            ignore_path.display()
+        )
+    })?;
+
+    Ok(ReplicaIgnoreConfig {
+        matcher,
+        user_patterns,
+    })
+}
+
+fn load_user_ignore_patterns(ignore_path: &Path) -> Result<Vec<String>> {
+    if !ignore_path.is_file() {
+        return Ok(Vec::new());
+    }
+
+    let content = std::fs::read_to_string(ignore_path)
+        .map_err(|source| anyhow!("failed to read {}: {source}", ignore_path.display()))?;
+    Ok(content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(ToString::to_string)
+        .collect())
+}
+
+fn copy_workspace_with_default_exclusions(
+    source: &Path,
+    copy: &Path,
+    ignore_config: &ReplicaIgnoreConfig,
+) -> Result<()> {
     if !source.is_dir() {
         return Err(anyhow!(
             "replica source workspace does not exist or is not a directory: {}",
@@ -302,7 +358,7 @@ fn copy_workspace_with_default_exclusions(source: &Path, copy: &Path) -> Result<
         )
     })?;
 
-    copy_directory_recursive(source, copy, source)?;
+    copy_directory_recursive(source, copy, source, ignore_config)?;
     Ok(())
 }
 
@@ -310,6 +366,7 @@ fn copy_directory_recursive(
     source_dir: &Path,
     target_dir: &Path,
     source_root: &Path,
+    ignore_config: &ReplicaIgnoreConfig,
 ) -> Result<()> {
     for entry in std::fs::read_dir(source_dir).map_err(|source_error| {
         anyhow!(
@@ -330,10 +387,6 @@ fn copy_directory_recursive(
                 anyhow!("failed to compute relative source path: {source_error}")
             })?;
 
-        if should_exclude_replica_path(relative_path) {
-            continue;
-        }
-
         let target_path = target_dir.join(entry.file_name());
         let file_type = entry.file_type().map_err(|source_error| {
             anyhow!(
@@ -341,6 +394,14 @@ fn copy_directory_recursive(
                 source_path.display()
             )
         })?;
+        if should_exclude_replica_path(
+            relative_path,
+            file_type.is_dir(),
+            source_root,
+            ignore_config,
+        ) {
+            continue;
+        }
 
         if file_type.is_dir() {
             std::fs::create_dir_all(&target_path).map_err(|source_error| {
@@ -349,7 +410,7 @@ fn copy_directory_recursive(
                     target_path.display()
                 )
             })?;
-            copy_directory_recursive(&source_path, &target_path, source_root)?;
+            copy_directory_recursive(&source_path, &target_path, source_root, ignore_config)?;
             continue;
         }
 
@@ -404,7 +465,24 @@ fn copy_symlink(source_path: &Path, target_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn should_exclude_replica_path(relative_path: &Path) -> bool {
+fn should_exclude_replica_path(
+    relative_path: &Path,
+    is_dir: bool,
+    source_root: &Path,
+    ignore_config: &ReplicaIgnoreConfig,
+) -> bool {
+    if should_exclude_default_replica_path(relative_path) {
+        return true;
+    }
+
+    let full_path = source_root.join(relative_path);
+    ignore_config
+        .matcher
+        .matched_path_or_any_parents(&full_path, is_dir)
+        .is_ignore()
+}
+
+fn should_exclude_default_replica_path(relative_path: &Path) -> bool {
     if relative_path == Path::new(".git/config") {
         return true;
     }
@@ -1085,9 +1163,9 @@ mod tests {
 
     use super::{
         build_execution_plan, copy_workspace_with_default_exclusions, doctor_rows,
-        execution_status, execution_status_from_exit_status, resolve_execution_path,
-        run_monitored_child, select_default_mode, should_exclude_replica_path, CommandArgs,
-        RunTermination,
+        execution_status, execution_status_from_exit_status, load_replica_ignore_config,
+        resolve_execution_path, run_monitored_child, select_default_mode,
+        should_exclude_default_replica_path, CommandArgs, RunTermination,
     };
     use clap::Parser;
     use clawcrate_profiles::ProfileResolver;
@@ -1266,14 +1344,18 @@ mod tests {
 
     #[test]
     fn should_exclude_replica_defaults() {
-        assert!(should_exclude_replica_path(Path::new(".env")));
-        assert!(should_exclude_replica_path(Path::new(".env.local")));
-        assert!(should_exclude_replica_path(Path::new(
+        assert!(should_exclude_default_replica_path(Path::new(".env")));
+        assert!(should_exclude_default_replica_path(Path::new(".env.local")));
+        assert!(should_exclude_default_replica_path(Path::new(
             "nested/.env.production"
         )));
-        assert!(should_exclude_replica_path(Path::new(".git/config")));
-        assert!(!should_exclude_replica_path(Path::new(".git/HEAD")));
-        assert!(!should_exclude_replica_path(Path::new("src/main.rs")));
+        assert!(should_exclude_default_replica_path(Path::new(
+            ".git/config"
+        )));
+        assert!(!should_exclude_default_replica_path(Path::new(".git/HEAD")));
+        assert!(!should_exclude_default_replica_path(Path::new(
+            "src/main.rs"
+        )));
     }
 
     #[test]
@@ -1292,7 +1374,9 @@ mod tests {
 
         let replica_root = unique_tmp_dir("clawcrate_cli_replica_copy_root");
         let replica = replica_root.join("workspace");
-        copy_workspace_with_default_exclusions(&source, &replica).expect("copy workspace");
+        let ignore_config = load_replica_ignore_config(&source).expect("load ignore config");
+        copy_workspace_with_default_exclusions(&source, &replica, &ignore_config)
+            .expect("copy workspace");
 
         assert!(!replica.join(".env").exists());
         assert!(!replica.join(".env.local").exists());
@@ -1303,6 +1387,30 @@ mod tests {
             fs::read_to_string(replica.join("nested/app.txt")).expect("read copied file"),
             "visible"
         );
+    }
+
+    #[test]
+    fn replica_copy_applies_clawcrateignore_patterns() {
+        let source = unique_tmp_dir("clawcrate_cli_replica_ignore_source");
+        fs::create_dir_all(source.join("nested").join("tmp")).expect("create nested tmp");
+
+        fs::write(source.join(".clawcrateignore"), "*.log\nnested/tmp/\n")
+            .expect("write .clawcrateignore");
+        fs::write(source.join("keep.txt"), "keep").expect("write keep file");
+        fs::write(source.join("skip.log"), "skip").expect("write skipped log");
+        fs::write(source.join("nested/tmp/skip.txt"), "skip").expect("write nested skip");
+        fs::write(source.join("nested/keep.md"), "keep").expect("write nested keep");
+
+        let replica_root = unique_tmp_dir("clawcrate_cli_replica_ignore_copy");
+        let replica = replica_root.join("workspace");
+        let ignore_config = load_replica_ignore_config(&source).expect("load ignore config");
+        copy_workspace_with_default_exclusions(&source, &replica, &ignore_config)
+            .expect("copy workspace with ignore rules");
+
+        assert!(replica.join("keep.txt").exists());
+        assert!(replica.join("nested/keep.md").exists());
+        assert!(!replica.join("skip.log").exists());
+        assert!(!replica.join("nested/tmp/skip.txt").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add .clawcrateignore parsing using gitignore-compatible matcher (ignore::gitignore)
- apply user ignore rules during replica workspace copy, on top of default exclusions
- include loaded user ignore patterns in ReplicaCreated audit event metadata
- add tests for default exclusions and .clawcrateignore filtering behavior
- update README replica section to document .clawcrateignore participation

## Validation
- cargo fmt
- cargo test -p clawcrate-cli
- cargo clippy -p clawcrate-cli -- -D warnings

Closes #31