### PR TITLE
docs: complete alpha technical docs pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ cargo clippy --workspace -- -D warnings
 
 See [CLAUDE.md](CLAUDE.md) for the complete development guide with architecture decisions, coding standards, and step-by-step build instructions.
 See [docs/WORKFLOW.md](docs/WORKFLOW.md) for the operational issue-to-PR workflow used in this repository.
+See [docs/architecture.md](docs/architecture.md), [docs/profiles-reference.md](docs/profiles-reference.md), [docs/kernel-requirements.md](docs/kernel-requirements.md), and [docs/integration-guide.md](docs/integration-guide.md) for the alpha technical docs pack.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,125 @@
+# ClawCrate Architecture (Alpha)
+
+This document describes the architecture currently implemented in the repository.
+
+## Scope
+
+Alpha command surface:
+
+- `clawcrate plan`
+- `clawcrate run`
+- `clawcrate doctor`
+
+Alpha architecture constraints:
+
+- Native platform sandboxing only (Linux + macOS)
+- No Docker or VM runtime in the execution path
+- File-based artifacts (`plan.json`, `result.json`, logs, `audit.ndjson`, `fs-diff.json`)
+
+## Workspace Layout
+
+```
+crates/
+├── clawcrate-types      # Shared types and event models
+├── clawcrate-profiles   # Profile loading, inheritance, stack auto-detect
+├── clawcrate-sandbox    # Linux/macOS backend prep + launch
+├── clawcrate-capture    # stdout/stderr capture + fs snapshot/diff
+├── clawcrate-audit      # Artifact writer (json + ndjson)
+└── clawcrate-cli        # CLI entrypoint and orchestration pipeline
+```
+
+Dependency direction is one-way from `clawcrate-cli` down into the leaf crates.
+
+## Execution Pipeline (`run`)
+
+`clawcrate-cli` orchestrates the full pipeline:
+
+1. Parse CLI args and global output options (`--verbose`, `--no-color`, `NO_COLOR`).
+2. Resolve profile (`safe`, `build`, `install`, `open`, or custom YAML path).
+3. Materialize execution mode:
+   - `DefaultMode` (profile intent) + CLI override (`--replica` / `--direct`)
+   - into `WorkspaceMode` (`Direct` or `Replica { source, copy }`)
+4. Write `plan.json`.
+5. If `Replica`, copy workspace to a temp directory with exclusions:
+   - defaults: `.env`, `.env.*`, `.git/config`
+   - plus `.clawcrateignore` rules
+6. Snapshot writable roots.
+7. Launch sandbox backend and capture stdout/stderr with output budget.
+8. Snapshot writable roots again and compute `fs-diff`.
+9. Optionally prompt sync-back for Replica mode:
+   - interactive: explicit confirmation
+   - `--json`: deterministic no-sync behavior
+10. Write final artifacts and print human/JSON summary.
+
+## Planning Pipeline (`plan`)
+
+`plan` runs steps 1-3 of the same resolution flow and emits an `ExecutionPlan`:
+
+- text table (human mode), or
+- full JSON object (`--json`).
+
+This keeps plan and run behavior aligned.
+
+## Doctor Pipeline (`doctor`)
+
+`doctor` probes local platform capability signals:
+
+- Linux:
+  - kernel version
+  - Landlock ABI (files + fallback checks)
+  - seccomp availability
+  - user namespaces availability
+- macOS:
+  - `sandbox-exec` presence/executability
+  - macOS version (`sw_vers`)
+  - kernel version (`uname -r`)
+
+Output is table or JSON.
+
+## Platform Backends
+
+## Linux backend
+
+Current backend path:
+
+- profile/env prep
+- launch flow and auditing
+- named enforcement stages (`rlimits`, `landlock`, `seccomp`)
+
+Important current state:
+
+- Enforcement steps are wired but currently no-op in `KernelEnforcer`.
+- Tracked as technical gap in issue `#69` ("Implement real Linux enforcement").
+
+## macOS backend
+
+Current backend path:
+
+- generate SBPL profile per execution
+- execute command via `/usr/bin/sandbox-exec -f <profile>`
+- cleanup temp SBPL profile after execution
+- apply filesystem/network policy + sensitive path denies in generated policy
+
+## Artifacts
+
+Each run writes under:
+
+`$HOME/.clawcrate/runs/<execution_id>/`
+
+Files:
+
+- `plan.json`
+- `result.json`
+- `stdout.log`
+- `stderr.log`
+- `audit.ndjson`
+- `fs-diff.json`
+
+The runtime treats the artifact directory as the source of truth for post-run inspection.
+
+## Current Architectural Notes
+
+- Replica mode is first-class and default for `install`.
+- `.clawcrateignore` is interpreted with gitignore-style matching.
+- Golden output tests are in place for `plan`, `run`, and `doctor` (text + JSON).
+- This document intentionally describes implemented behavior, not planned future behavior.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,0 +1,119 @@
+# Integration Guide (Alpha)
+
+This guide shows how to integrate ClawCrate as the execution boundary for agent/tooling workflows.
+
+## Core Integration Rule
+
+Always invoke commands with argument separation:
+
+```bash
+clawcrate run --profile <profile> -- <command> <arg1> <arg2>
+```
+
+Do not pass a shell command string unless you explicitly need shell features.
+
+## Common Patterns
+
+## Plan before execution
+
+```bash
+clawcrate plan --profile build --json -- cargo test
+```
+
+Use this to inspect mode, cwd, and profile policy without running the command.
+
+## Run with machine-readable output
+
+```bash
+clawcrate run --profile safe --json -- cargo test
+```
+
+The JSON summary includes:
+
+- `result.status`
+- `result.exit_code`
+- `result.artifacts_dir`
+- capture metadata (`stdout_log`, `stderr_log`, truncation counters)
+
+## Collect artifacts
+
+Given `result.artifacts_dir`, consume:
+
+- `plan.json`
+- `result.json`
+- `audit.ndjson`
+- `fs-diff.json`
+- `stdout.log`
+- `stderr.log`
+
+This keeps integrations deterministic and auditable.
+
+## Profile Selection Strategy
+
+Recommended default profile mapping:
+
+- read-only/static checks: `safe`
+- build/test workflows: `build`
+- dependency install flows: `install`
+- trusted unrestricted workspace tasks: `open`
+
+`install` defaults to Replica mode by design.
+
+## Replica Mode Integration Notes
+
+- Interactive human mode: may prompt for sync-back confirmation.
+- `--json` mode: sync-back is always skipped (deterministic non-interactive behavior).
+
+For automation, use `--json` to avoid prompts.
+
+## Verbosity and Color
+
+Global flags:
+
+- `-v` / `--verbose`: include diagnostic logs (stderr)
+- `--no-color`: disable ANSI color in human output
+
+Environment:
+
+- `NO_COLOR=1` also disables ANSI color
+
+## Error Handling Recommendations
+
+If `clawcrate` exits non-zero:
+
+1. Parse stderr for `error: ...` and optional hints.
+2. Re-run with `--verbose` when deeper cause chain is needed.
+3. If a run started, inspect `result.json` and `audit.ndjson` in artifacts.
+
+## Wrapper Example (Shell Function)
+
+```bash
+cc_run() {
+  local profile="$1"
+  shift
+  clawcrate run --profile "$profile" --json -- "$@"
+}
+
+# usage
+cc_run build cargo test --release
+```
+
+## CI/Automation Example
+
+```bash
+set -euo pipefail
+
+summary="$(clawcrate run --profile build --json -- cargo test)"
+status="$(printf '%s' "$summary" | jq -r '.result.status')"
+
+if [ "$status" != "Success" ]; then
+  echo "clawcrate run failed with status=$status" >&2
+  exit 1
+fi
+```
+
+## Current Alpha Caveats
+
+- Linux full kernel enforcement is tracked as ongoing work (issue `#69`).
+- macOS and Linux differ in backend internals; keep your integration backend-agnostic by consuming `result` + artifacts.
+- Domain-level network filtering is not part of alpha (`none` vs `open` only).

--- a/docs/kernel-requirements.md
+++ b/docs/kernel-requirements.md
@@ -1,0 +1,96 @@
+# Kernel and Platform Requirements (Alpha)
+
+This page describes current platform assumptions for alpha behavior.
+
+## Supported Platforms
+
+- Linux
+- macOS
+
+Other platforms currently return unsupported errors for `run`/`doctor`.
+
+## Linux
+
+## Minimum baseline
+
+- Linux kernel 5.13+ is the practical baseline for Landlock availability.
+
+## Capability checks used by `doctor`
+
+`clawcrate doctor` reports:
+
+- kernel version (`/proc/sys/kernel/osrelease`)
+- Landlock ABI (from known sysfs paths, with fallback heuristics)
+- seccomp availability
+- user namespaces availability
+
+## Current enforcement note
+
+In the current alpha codebase, Linux launch stages are wired as:
+
+- `rlimits`
+- `landlock`
+- `seccomp`
+
+But the default `KernelEnforcer` implementation is currently no-op for those steps.
+Tracked in issue `#69` ("Implement real Linux enforcement").
+
+That means Linux capability detection is present, but full enforcement remains an active gap.
+
+## macOS
+
+## Minimum baseline
+
+- macOS with `/usr/bin/sandbox-exec` available.
+
+## Capability checks used by `doctor`
+
+`clawcrate doctor` reports:
+
+- seatbelt availability (`sandbox-exec` executable check)
+- macOS version (`sw_vers -productVersion`)
+- kernel version (`uname -r`)
+
+## Enforcement path
+
+Current backend behavior:
+
+- generate SBPL profile per execution
+- execute target command via `sandbox-exec`
+- clean up temporary SBPL profile file after execution
+
+## Resource Limits
+
+The project includes rlimit mapping and application helpers in `clawcrate-sandbox::rlimits`.
+These limits map profile resources to:
+
+- CPU time
+- virtual memory
+- open files
+- file size
+- process count (platform conditional)
+
+Integration into platform launch behavior is in progress and should be interpreted alongside issue `#69`.
+
+## Replica Mode and Secret Handling
+
+For high-risk operations, `install` defaults to Replica mode.
+
+Replica copy exclusions currently include:
+
+- `.env`
+- `.env.*`
+- `.git/config`
+- additional `.clawcrateignore` rules
+
+This filtering is cross-platform and independent of kernel-level deny semantics.
+
+## Recommended Verification Command
+
+Run this on target hosts:
+
+```bash
+clawcrate doctor --json
+```
+
+Use the JSON output in CI/automation to gate where specific profiles are allowed.

--- a/docs/profiles-reference.md
+++ b/docs/profiles-reference.md
@@ -1,0 +1,131 @@
+# Profiles Reference (Alpha)
+
+This reference covers built-in and custom profiles as implemented in `clawcrate-profiles`.
+
+## Built-in Profiles
+
+Built-ins are loaded from `profiles/*.yaml`:
+
+- `safe`
+- `build`
+- `install`
+- `open`
+
+## `safe`
+
+- `default_mode`: `Direct`
+- `network`: `none`
+- Filesystem:
+  - read: `.`
+  - write: none
+- Intended use:
+  - read-only commands (lint/check/inspect)
+
+## `build`
+
+- `default_mode`: `Direct`
+- `network`: `none`
+- Filesystem:
+  - read: workspace + toolchain/cache paths
+  - write: `./target`, `./dist`, `./build`
+- Intended use:
+  - compilation and test workflows without network
+
+## `install`
+
+- `default_mode`: `Replica`
+- `network`: `open`
+- Filesystem:
+  - broad read/write suitable for dependency installs
+- Intended use:
+  - package installs (`npm`, `pip`, `cargo` fetch/install flows)
+- Security posture:
+  - Replica mode default helps protect source workspace from secret file exposure
+
+## `open`
+
+- `default_mode`: `Direct`
+- `network`: `open`
+- Filesystem:
+  - read/write workspace
+- Intended use:
+  - least restrictive profile for trusted tasks
+
+## Mode Resolution Rules
+
+Execution mode is resolved with this precedence:
+
+1. CLI override flags (`--replica` or `--direct`)
+2. Profile `default_mode`
+
+Then materialized to runtime mode:
+
+- `Direct`
+- `Replica { source, copy }`
+
+## Auto Detection (`--profile` omitted)
+
+Resolver behavior:
+
+- `Cargo.toml` found: treat as Rust stack
+- `package.json` found: treat as Node stack
+- `pyproject.toml` found: treat as Python stack
+- none found: fallback to `safe`
+
+Current auto profile selection:
+
+- known stacks resolve from `build` with stack-specific path/env overrides
+- unknown stack resolves to `safe`
+
+## Custom Profiles (YAML)
+
+A custom profile can be provided by file path:
+
+```bash
+clawcrate run --profile .clawcrate/custom.yaml -- make build
+```
+
+Supported fields:
+
+```yaml
+name: my-profile
+extends: build
+default_mode: direct   # direct | replica
+filesystem:
+  read: ["."]
+  write: ["./target"]
+  deny: []
+network: none          # none | open
+environment:
+  scrub: ["*_SECRET*", "AWS_*"]
+  passthrough: ["HOME", "PATH"]
+resources:
+  max_cpu_seconds: 120
+  max_memory_mb: 2048
+  max_open_files: 1024
+  max_processes: 128
+  max_output_bytes: 2097152
+```
+
+`extends` supports:
+
+- built-in name (for example `build`)
+- relative YAML path
+- absolute YAML path
+
+Inheritance is merged field-by-field and cycle-checked.
+
+## Validation Rules
+
+Parser behavior includes:
+
+- unknown YAML fields are rejected (`deny_unknown_fields`)
+- invalid `network` values fail profile load
+- invalid `default_mode` values fail profile load
+- missing profile file fails with explicit path error
+
+## Notes on Filesystem Deny
+
+- `fs_deny` is currently consumed in macOS SBPL profile generation.
+- Linux intra-workspace deny behavior depends on Landlock implementation status.
+- For sensitive file filtering in alpha, use Replica mode + default exclusions + `.clawcrateignore`.


### PR DESCRIPTION
## Summary
- add architecture reference aligned to current alpha implementation
- add profiles reference for built-in/custom profiles and mode resolution
- add platform and kernel requirements guide with current Linux/macOS capability notes
- add integration guide for plan/run/doctor automation patterns and artifact consumption
- link the new docs pack from README contributing section

## Validation
- cargo fmt
- cargo clippy -p clawcrate-cli -- -D warnings
- cargo test -p clawcrate-cli

Closes #37