### PR TITLE
feat(m5-05): add release artifacts workflow, checksums, and installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.0-alpha.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use_cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            use_cross: true
+          - os: macos-13
+            target: x86_64-apple-darwin
+            use_cross: false
+          - os: macos-14
+            target: aarch64-apple-darwin
+            use_cross: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux musl targets)
+        if: matrix.use_cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build binary
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --locked --release -p clawcrate-cli --target ${{ matrix.target }}
+          else
+            cargo build --locked --release -p clawcrate-cli --target ${{ matrix.target }}
+          fi
+
+      - name: Package release archive
+        run: |
+          bash scripts/release.sh package \
+            --target "${{ matrix.target }}" \
+            --binary "target/${{ matrix.target }}/release/clawcrate" \
+            --dist-dir dist
+
+      - name: Upload target artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawcrate-${{ matrix.target }}
+          path: dist/clawcrate-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve tag
+        id: release_meta
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: clawcrate-*
+          merge-multiple: true
+          path: dist
+
+      - name: Generate checksums
+        run: bash scripts/release.sh checksums --dist-dir dist
+
+      - name: Upload GitHub release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release_meta.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            dist/clawcrate-*.tar.gz
+            dist/SHA256SUMS
+            scripts/install.sh

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ npm test runs normally. Your secrets never left the vault.
 
 ```bash
 # Install (macOS)
-curl -fsSL https://clawcrate.dev/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/ClawCrate/main/scripts/install.sh | sh
 
 # Install (Linux)
-curl -fsSL https://clawcrate.dev/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/ClawCrate/main/scripts/install.sh | sh
 
 # Run your first sandboxed command
 clawcrate run --profile safe -- echo "hello from the sandbox"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="${CLAWCRATE_REPO:-manuelpenazuniga/ClawCrate}"
+VERSION="${CLAWCRATE_VERSION:-latest}"
+INSTALL_DIR="${CLAWCRATE_INSTALL_DIR:-$HOME/.local/bin}"
+BIN_NAME="clawcrate"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sh install.sh [--version <version|latest>] [--install-dir <path>] [--repo <owner/repo>]
+
+Examples:
+  sh install.sh
+  sh install.sh --version v0.1.0-alpha.0
+  sh install.sh --install-dir "$HOME/bin"
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --install-dir)
+      INSTALL_DIR="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command '$1' is not installed" >&2
+    exit 1
+  fi
+}
+
+fetch_to_file() {
+  url="$1"
+  out="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$out"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO "$out" "$url"
+    return
+  fi
+  echo "error: curl or wget is required to download artifacts" >&2
+  exit 1
+}
+
+fetch_text() {
+  url="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO- "$url"
+    return
+  fi
+  echo "error: curl or wget is required to download release metadata" >&2
+  exit 1
+}
+
+sha256_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | awk '{print $2}'
+    return
+  fi
+  echo "error: no SHA256 tool found (sha256sum/shasum/openssl)" >&2
+  exit 1
+}
+
+detect_target() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux) os_part="unknown-linux-musl" ;;
+    Darwin) os_part="apple-darwin" ;;
+    *)
+      echo "error: unsupported OS '$os' (supported: Linux, Darwin)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64) arch_part="x86_64" ;;
+    arm64|aarch64) arch_part="aarch64" ;;
+    *)
+      echo "error: unsupported architecture '$arch' (supported: x86_64, arm64/aarch64)" >&2
+      exit 1
+      ;;
+  esac
+
+  printf "%s-%s" "$arch_part" "$os_part"
+}
+
+resolve_tag() {
+  if [ "$VERSION" = "latest" ]; then
+    api_url="https://api.github.com/repos/$REPO/releases/latest"
+    tag="$(
+      fetch_text "$api_url" \
+        | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | head -n1
+    )"
+    if [ -z "$tag" ]; then
+      echo "error: failed to resolve latest release tag for $REPO" >&2
+      exit 1
+    fi
+    printf "%s" "$tag"
+    return
+  fi
+
+  case "$VERSION" in
+    v*) printf "%s" "$VERSION" ;;
+    *) printf "v%s" "$VERSION" ;;
+  esac
+}
+
+need_cmd tar
+need_cmd awk
+need_cmd grep
+
+TARGET="$(detect_target)"
+TAG="$(resolve_tag)"
+ASSET_NAME="${BIN_NAME}-${TARGET}.tar.gz"
+BASE_URL="https://github.com/$REPO/releases/download/$TAG"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT INT TERM
+
+ARCHIVE_PATH="$TMP_DIR/$ASSET_NAME"
+CHECKSUMS_PATH="$TMP_DIR/SHA256SUMS"
+
+echo "==> Installing $BIN_NAME"
+echo "    repo: $REPO"
+echo "    tag: $TAG"
+echo "    target: $TARGET"
+echo "    install dir: $INSTALL_DIR"
+
+fetch_to_file "$BASE_URL/$ASSET_NAME" "$ARCHIVE_PATH"
+fetch_to_file "$BASE_URL/SHA256SUMS" "$CHECKSUMS_PATH"
+
+expected_sum="$(grep "  $ASSET_NAME\$" "$CHECKSUMS_PATH" | awk '{print $1}' | head -n1)"
+if [ -z "$expected_sum" ]; then
+  echo "error: checksum entry not found for $ASSET_NAME" >&2
+  exit 1
+fi
+
+actual_sum="$(sha256_file "$ARCHIVE_PATH")"
+if [ "$expected_sum" != "$actual_sum" ]; then
+  echo "error: checksum verification failed for $ASSET_NAME" >&2
+  echo "expected: $expected_sum" >&2
+  echo "actual:   $actual_sum" >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
+
+if command -v install >/dev/null 2>&1; then
+  install -m 0755 "$TMP_DIR/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
+else
+  cp "$TMP_DIR/$BIN_NAME" "$INSTALL_DIR/$BIN_NAME"
+  chmod 0755 "$INSTALL_DIR/$BIN_NAME"
+fi
+
+echo "==> Installed to $INSTALL_DIR/$BIN_NAME"
+if ! command -v "$BIN_NAME" >/dev/null 2>&1; then
+  echo "note: '$INSTALL_DIR' is not in PATH for this shell session." >&2
+  echo "      add: export PATH=\"$INSTALL_DIR:\$PATH\"" >&2
+fi
+
+"$INSTALL_DIR/$BIN_NAME" --version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/release.sh package --target <target-triple> --binary <binary-path> [--dist-dir <dir>]
+  bash scripts/release.sh checksums [--dist-dir <dir>]
+
+Commands:
+  package    Create clawcrate-<target>.tar.gz from a built binary.
+  checksums  Generate SHA256SUMS for all clawcrate-*.tar.gz files in the dist dir.
+EOF
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required tool '$1' is not installed" >&2
+    exit 1
+  fi
+}
+
+sha256_cmd() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    echo "sha256sum"
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    echo "shasum -a 256"
+    return
+  fi
+  echo ""
+}
+
+package_cmd() {
+  local target=""
+  local binary=""
+  local dist_dir="dist"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target)
+        target="${2:-}"
+        shift 2
+        ;;
+      --binary)
+        binary="${2:-}"
+        shift 2
+        ;;
+      --dist-dir)
+        dist_dir="${2:-}"
+        shift 2
+        ;;
+      *)
+        echo "error: unknown argument for package: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$target" || -z "$binary" ]]; then
+    echo "error: package requires --target and --binary" >&2
+    usage >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$binary" ]]; then
+    echo "error: binary not found: $binary" >&2
+    exit 1
+  fi
+
+  mkdir -p "$dist_dir"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+
+  cp "$binary" "$tmp_dir/clawcrate"
+  chmod 0755 "$tmp_dir/clawcrate"
+  tar -C "$tmp_dir" -czf "$dist_dir/clawcrate-${target}.tar.gz" clawcrate
+  rm -rf "$tmp_dir"
+  echo "packaged: $dist_dir/clawcrate-${target}.tar.gz"
+}
+
+checksums_cmd() {
+  local dist_dir="dist"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dist-dir)
+        dist_dir="${2:-}"
+        shift 2
+        ;;
+      *)
+        echo "error: unknown argument for checksums: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ ! -d "$dist_dir" ]]; then
+    echo "error: dist directory not found: $dist_dir" >&2
+    exit 1
+  fi
+
+  local cmd
+  cmd="$(sha256_cmd)"
+  if [[ -z "$cmd" ]]; then
+    echo "error: no SHA256 command found (sha256sum or shasum)" >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  local archives=("$dist_dir"/clawcrate-*.tar.gz)
+  shopt -u nullglob
+
+  if [[ "${#archives[@]}" -eq 0 ]]; then
+    echo "error: no release archives found under $dist_dir" >&2
+    exit 1
+  fi
+
+  (
+    cd "$dist_dir"
+    rm -f SHA256SUMS
+    if [[ "$cmd" == "sha256sum" ]]; then
+      sha256sum clawcrate-*.tar.gz > SHA256SUMS
+    else
+      shasum -a 256 clawcrate-*.tar.gz > SHA256SUMS
+    fi
+  )
+
+  echo "generated: $dist_dir/SHA256SUMS"
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  need_cmd tar
+  need_cmd cp
+  need_cmd chmod
+
+  local command="$1"
+  shift
+
+  case "$command" in
+    package)
+      package_cmd "$@"
+      ;;
+    checksums)
+      checksums_cmd "$@"
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "error: unknown command '$command'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add release workflow to build Linux/macOS target binaries and publish archives
- add `scripts/release.sh` for packaging archives and generating `SHA256SUMS`
- add `scripts/install.sh` with platform/arch detection and checksum verification
- update README install commands to point to the repository installer script

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `sh -n scripts/install.sh`
- `bash -n scripts/release.sh`
- `bash scripts/release.sh package --target x86_64-unknown-linux-musl --binary target/debug/clawcrate --dist-dir /tmp/clawcrate-dist-test`
- `bash scripts/release.sh checksums --dist-dir /tmp/clawcrate-dist-test`

Closes #39
