### PR TITLE
chore(m5-06): add alpha release checklist, changelog, and cut script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+with alpha pre-release tags.
+
+## [Unreleased]
+
+### Added
+- Release automation workflow for multi-target binary artifacts and checksum publication.
+- Install script with platform/architecture detection and SHA256 verification.
+
+## [0.1.0-alpha.0] - 2026-04-18
+
+### Added
+- Initial alpha for `run`, `plan`, and `doctor` commands.
+- Native sandbox backends:
+  Linux: Landlock + seccomp + rlimits.
+  macOS: Seatbelt (`sandbox-exec`) + rlimits.
+- Built-in profiles: `safe`, `build`, `install`, `open`.
+- Replica mode with `.clawcrateignore` support and explicit sync-back flow.
+- Execution artifacts:
+  `plan.json`, `result.json`, `stdout.log`, `stderr.log`, `audit.ndjson`, `fs-diff.json`.
+- Linux/macOS CI matrix with integration and security fixtures.
+- Golden CLI output tests for text and JSON modes.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ cargo clippy --workspace -- -D warnings
 
 See [CLAUDE.md](CLAUDE.md) for the complete development guide with architecture decisions, coding standards, and step-by-step build instructions.
 See [docs/WORKFLOW.md](docs/WORKFLOW.md) for the operational issue-to-PR workflow used in this repository.
+See [CHANGELOG.md](CHANGELOG.md) for release notes and version history.
+See [docs/release-checklist.md](docs/release-checklist.md) for the alpha release and tagging runbook.
 See [docs/architecture.md](docs/architecture.md), [docs/profiles-reference.md](docs/profiles-reference.md), [docs/kernel-requirements.md](docs/kernel-requirements.md), and [docs/integration-guide.md](docs/integration-guide.md) for the alpha technical docs pack.
 
 ## License

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,92 @@
+# Alpha Release Checklist
+
+This checklist is the operational guide for `M5-06`:
+execute alpha release criteria and publish a tagged release with artifacts.
+
+## 1. Preconditions
+
+- Work from a clean local repository.
+- Ensure `main` is synchronized with `origin/main`.
+- Confirm the release issue is in scope:
+  `https://github.com/manuelpenazuniga/ClawCrate/issues/40`.
+
+Commands:
+
+```bash
+git fetch --all --prune
+git switch main
+git pull --ff-only
+git status -sb
+git rev-parse main origin/main
+```
+
+Expected:
+- `git status -sb` shows `## main...origin/main`.
+- `git rev-parse` returns the same commit hash twice.
+
+## 2. Validate Release Criteria
+
+Run the full quality gate before creating a tag:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Optional local packaging sanity check:
+
+```bash
+cargo build -p clawcrate-cli
+bash scripts/release.sh package \
+  --target x86_64-unknown-linux-musl \
+  --binary target/debug/clawcrate \
+  --dist-dir /tmp/clawcrate-dist-local
+bash scripts/release.sh checksums --dist-dir /tmp/clawcrate-dist-local
+```
+
+## 3. Update Changelog
+
+- Update `[Unreleased]` in [`CHANGELOG.md`](../CHANGELOG.md).
+- Add a new version section with date and key user-visible changes.
+
+## 4. Create and Push Tag
+
+Use the helper script:
+
+```bash
+bash scripts/cut_release.sh --tag v0.1.0-alpha.0 --push
+```
+
+What it enforces:
+- clean working tree
+- `main` branch only
+- local `main` equals `origin/main`
+- local quality gate (`fmt`, `clippy`, `test`)
+- annotated tag creation
+- optional remote push
+
+## 5. Publish Artifacts (GitHub Actions)
+
+After tag push:
+- Workflow [`Release`](../.github/workflows/release.yml) runs automatically.
+- It builds and uploads:
+  - `clawcrate-x86_64-unknown-linux-musl.tar.gz`
+  - `clawcrate-aarch64-unknown-linux-musl.tar.gz`
+  - `clawcrate-x86_64-apple-darwin.tar.gz`
+  - `clawcrate-aarch64-apple-darwin.tar.gz`
+  - `SHA256SUMS`
+  - `scripts/install.sh`
+
+## 6. Post-Release Verification
+
+- Confirm GitHub Release exists for the pushed tag.
+- Verify all expected assets are attached.
+- Smoke test installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/ClawCrate/main/scripts/install.sh | sh
+clawcrate --version
+```
+
+- Close the release issue via merge automation (`Closes #40`) or manually if needed.

--- a/scripts/cut_release.sh
+++ b/scripts/cut_release.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/cut_release.sh --tag <vX.Y.Z[-alpha.N]> [--push] [--skip-verify]
+
+Options:
+  --tag           Release tag to create (required).
+  --push          Push created tag to origin.
+  --skip-verify   Skip cargo fmt/clippy/test gate.
+EOF
+}
+
+TAG=""
+PUSH=0
+SKIP_VERIFY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      TAG="${2:-}"
+      shift 2
+      ;;
+    --push)
+      PUSH=1
+      shift
+      ;;
+    --skip-verify)
+      SKIP_VERIFY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  echo "error: --tag is required" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: tag '$TAG' does not look like semver (expected e.g. v0.1.0-alpha.0)" >&2
+  exit 1
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command '$1' is not installed" >&2
+    exit 1
+  fi
+}
+
+require_cmd git
+require_cmd cargo
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$current_branch" != "main" ]]; then
+  echo "error: release must be cut from 'main' (current: $current_branch)" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "error: working tree is not clean; commit/stash changes first" >&2
+  exit 1
+fi
+
+local_main="$(git rev-parse main)"
+remote_main="$(git rev-parse origin/main)"
+if [[ "$local_main" != "$remote_main" ]]; then
+  echo "error: local main ($local_main) is not synchronized with origin/main ($remote_main)" >&2
+  echo "hint: run 'git fetch --all --prune && git pull --ff-only'" >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  echo "error: tag '$TAG' already exists locally" >&2
+  exit 1
+fi
+
+if [[ "$SKIP_VERIFY" -eq 0 ]]; then
+  echo "==> Running release quality gate"
+  cargo fmt --all -- --check
+  cargo clippy --workspace --all-targets -- -D warnings
+  cargo test --workspace
+else
+  echo "==> Skipping release quality gate (--skip-verify)"
+fi
+
+echo "==> Creating annotated tag $TAG"
+git tag -a "$TAG" -m "Release $TAG"
+
+if [[ "$PUSH" -eq 1 ]]; then
+  echo "==> Pushing tag $TAG to origin"
+  git push origin "$TAG"
+  echo "==> Done. GitHub Release workflow should start from tag push."
+else
+  echo "==> Tag created locally."
+  echo "    Push with: git push origin $TAG"
+fi


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md` as the release history baseline for alpha
- add `docs/release-checklist.md` with end-to-end checklist for validation, tagging, and artifact publication
- add `scripts/cut_release.sh` to enforce clean/synced `main`, run quality gate, and create/push release tags
- link changelog and release checklist from `README.md`

## Validation
- `bash -n scripts/cut_release.sh`
- `bash scripts/cut_release.sh --help`
- `bash scripts/cut_release.sh --tag v0.1.0-alpha.0 --skip-verify` (expected fail outside `main`)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #40
