### PR TITLE
feat(p1-02): add filtered egress proxy MVP with domain rules

### DIFF
--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -17,6 +17,7 @@ use clawcrate_capture::{
 use clawcrate_profiles::ProfileResolver;
 #[cfg(target_os = "macos")]
 use clawcrate_sandbox::darwin::DarwinSandbox;
+use clawcrate_sandbox::egress_proxy::{start_egress_proxy, EgressProxyConfig, EgressProxyHandle};
 #[cfg(target_os = "linux")]
 use clawcrate_sandbox::linux::LinuxSandbox;
 #[cfg(target_os = "linux")]
@@ -24,8 +25,8 @@ use clawcrate_sandbox::linux_probe::probe_linux_capabilities;
 #[cfg(target_os = "macos")]
 use clawcrate_sandbox::macos_probe::probe_macos_capabilities;
 use clawcrate_types::{
-    Actor, AuditEvent, AuditEventKind, DefaultMode, ExecutionPlan, ExecutionResult, Platform,
-    Status, SystemCapabilities, WorkspaceMode,
+    Actor, AuditEvent, AuditEventKind, DefaultMode, ExecutionPlan, ExecutionResult, NetLevel,
+    Platform, Status, SystemCapabilities, WorkspaceMode,
 };
 use comfy_table::{Cell, Table};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
@@ -841,6 +842,29 @@ fn resolve_execution_path(cwd: &Path, path: &Path) -> PathBuf {
     }
 }
 
+fn maybe_start_filtered_egress_proxy(
+    net: &NetLevel,
+    env: &mut Vec<(String, String)>,
+) -> Result<Option<EgressProxyHandle>> {
+    let NetLevel::Filtered { allowed_domains } = net else {
+        return Ok(None);
+    };
+
+    let proxy = start_egress_proxy(EgressProxyConfig::from_allowed_domains(
+        allowed_domains.clone(),
+    ))
+    .map_err(|source| anyhow!("failed to start filtered egress proxy: {source}"))?;
+    upsert_env_vars(env, &proxy.proxy_env_vars());
+    Ok(Some(proxy))
+}
+
+fn upsert_env_vars(env: &mut Vec<(String, String)>, values: &[(String, String)]) {
+    for (key, value) in values {
+        env.retain(|(existing_key, _)| existing_key != key);
+        env.push((key.clone(), value.clone()));
+    }
+}
+
 fn expand_home(path: &Path) -> PathBuf {
     let path_str = path.to_string_lossy();
     if path_str == "~" {
@@ -895,18 +919,24 @@ fn launch_and_capture(
     capture_config: &CaptureConfig,
 ) -> Result<RunExecutionOutcome> {
     let sandbox = LinuxSandbox::new();
-    let prepared = sandbox.prepare(plan);
+    let mut prepared = sandbox.prepare(plan);
+    let egress_proxy =
+        maybe_start_filtered_egress_proxy(&plan.profile.net, &mut prepared.scrubbed_env)?;
     let scrubbed_keys = prepared.scrubbed_keys.clone();
 
+    let mut capabilities = vec![
+        "rlimits".to_string(),
+        "landlock".to_string(),
+        "seccomp".to_string(),
+    ];
+    if egress_proxy.is_some() {
+        capabilities.push("egress-proxy".to_string());
+    }
     append_audit_event(
         writer,
         AuditEventKind::SandboxApplied {
             backend: "linux".to_string(),
-            capabilities: vec![
-                "rlimits".to_string(),
-                "landlock".to_string(),
-                "seccomp".to_string(),
-            ],
+            capabilities,
         },
     )?;
     if !scrubbed_keys.is_empty() {
@@ -949,6 +979,7 @@ fn launch_and_capture(
         capture_config,
         plan.profile.resources.max_cpu_seconds,
     )?;
+    drop(egress_proxy);
 
     Ok(RunExecutionOutcome {
         backend: "linux".to_string(),
@@ -966,14 +997,20 @@ fn launch_and_capture(
     capture_config: &CaptureConfig,
 ) -> Result<RunExecutionOutcome> {
     let sandbox = DarwinSandbox::new();
-    let prepared = sandbox.prepare(plan);
+    let mut prepared = sandbox.prepare(plan);
+    let egress_proxy =
+        maybe_start_filtered_egress_proxy(&plan.profile.net, &mut prepared.scrubbed_env)?;
     let scrubbed_keys = prepared.scrubbed_keys.clone();
 
+    let mut capabilities = vec!["seatbelt".to_string()];
+    if egress_proxy.is_some() {
+        capabilities.push("egress-proxy".to_string());
+    }
     append_audit_event(
         writer,
         AuditEventKind::SandboxApplied {
             backend: "macos-seatbelt".to_string(),
-            capabilities: vec!["seatbelt".to_string()],
+            capabilities,
         },
     )?;
     if !scrubbed_keys.is_empty() {
@@ -1016,6 +1053,7 @@ fn launch_and_capture(
         capture_config,
         plan.profile.resources.max_cpu_seconds,
     )?;
+    drop(egress_proxy);
 
     Ok(RunExecutionOutcome {
         backend: "macos-seatbelt".to_string(),
@@ -1470,8 +1508,13 @@ fn print_human_plan(plan: &ExecutionPlan, _output: &OutputOptions) {
         .add_row(vec![
             Cell::new("Network"),
             Cell::new(match plan.profile.net {
-                clawcrate_types::NetLevel::None => "none",
-                clawcrate_types::NetLevel::Open => "open",
+                NetLevel::None => "none".to_string(),
+                NetLevel::Open => "open".to_string(),
+                NetLevel::Filtered {
+                    ref allowed_domains,
+                } => {
+                    format!("filtered ({})", allowed_domains.len())
+                }
             }),
         ])
         .add_row(vec![

--- a/crates/clawcrate-profiles/src/lib.rs
+++ b/crates/clawcrate-profiles/src/lib.rs
@@ -35,6 +35,8 @@ pub enum ProfileError {
     },
     #[error("invalid network value in {path}: {value}")]
     InvalidNetwork { path: PathBuf, value: String },
+    #[error("invalid filtered network config in {path}: {reason}")]
+    InvalidFilteredNetwork { path: PathBuf, reason: String },
     #[error("invalid default_mode value in {path}: {value}")]
     InvalidDefaultMode { path: PathBuf, value: String },
     #[error("cyclic profile inheritance detected at {0}")]
@@ -143,7 +145,7 @@ impl ProfileResolver {
         fallback_name: String,
     ) -> Result<ResolvedProfile, ProfileError> {
         let path = inherited.source_path;
-        let network = parse_network(inherited.network.as_deref(), &path)?;
+        let network = parse_network(inherited.network.clone(), &path)?;
         let default_mode = parse_default_mode(inherited.default_mode.as_deref(), &path)?;
 
         let fs_read = inherited
@@ -232,7 +234,7 @@ struct RawProfile {
     extends: Option<String>,
     default_mode: Option<String>,
     filesystem: RawFilesystem,
-    network: Option<String>,
+    network: Option<RawNetwork>,
     environment: RawEnvironment,
     resources: RawResources,
 }
@@ -262,12 +264,27 @@ struct RawResources {
     max_output_bytes: Option<u64>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum RawNetwork {
+    String(String),
+    Config(RawNetworkConfig),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawNetworkConfig {
+    mode: String,
+    #[serde(default)]
+    allowed_domains: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 struct InheritedProfile {
     name: Option<String>,
     default_mode: Option<String>,
     filesystem: RawFilesystem,
-    network: Option<String>,
+    network: Option<RawNetwork>,
     environment: RawEnvironment,
     resources: RawResources,
     source_path: PathBuf,
@@ -354,20 +371,65 @@ fn parse_default_mode(raw: Option<&str>, path: &Path) -> Result<DefaultMode, Pro
     }
 }
 
-fn parse_network(raw: Option<&str>, path: &Path) -> Result<NetLevel, ProfileError> {
-    match raw.map(normalize_string) {
+fn parse_network(raw: Option<RawNetwork>, path: &Path) -> Result<NetLevel, ProfileError> {
+    parse_network_config(raw, path)
+}
+
+fn parse_network_config(raw: Option<RawNetwork>, path: &Path) -> Result<NetLevel, ProfileError> {
+    match raw {
         None => Ok(NetLevel::None),
-        Some(network) if network == "none" => Ok(NetLevel::None),
-        Some(network) if network == "open" => Ok(NetLevel::Open),
-        Some(value) => Err(ProfileError::InvalidNetwork {
+        Some(RawNetwork::String(value)) => parse_network_mode_string(&value, path),
+        Some(RawNetwork::Config(config)) => {
+            let mode = normalize_string(&config.mode);
+            match mode.as_str() {
+                "none" => Ok(NetLevel::None),
+                "open" => Ok(NetLevel::Open),
+                "filtered" => {
+                    let allowed_domains = normalize_allowed_domains(&config.allowed_domains);
+                    if allowed_domains.is_empty() {
+                        return Err(ProfileError::InvalidFilteredNetwork {
+                            path: path.to_path_buf(),
+                            reason: "allowed_domains must contain at least one domain rule"
+                                .to_string(),
+                        });
+                    }
+                    Ok(NetLevel::Filtered { allowed_domains })
+                }
+                _ => Err(ProfileError::InvalidNetwork {
+                    path: path.to_path_buf(),
+                    value: mode,
+                }),
+            }
+        }
+    }
+}
+
+fn parse_network_mode_string(raw: &str, path: &Path) -> Result<NetLevel, ProfileError> {
+    let mode = normalize_string(raw);
+    match mode.as_str() {
+        "none" => Ok(NetLevel::None),
+        "open" => Ok(NetLevel::Open),
+        "filtered" => Err(ProfileError::InvalidFilteredNetwork {
             path: path.to_path_buf(),
-            value,
+            reason: "network: filtered requires object form with allowed_domains".to_string(),
+        }),
+        _ => Err(ProfileError::InvalidNetwork {
+            path: path.to_path_buf(),
+            value: mode,
         }),
     }
 }
 
 fn normalize_string(input: &str) -> String {
     input.trim().to_ascii_lowercase()
+}
+
+fn normalize_allowed_domains(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| normalize_string(value))
+        .filter(|value| !value.is_empty())
+        .collect()
 }
 
 fn looks_like_path(reference: &str) -> bool {
@@ -637,5 +699,56 @@ network: open
             .env_passthrough
             .iter()
             .any(|it| it == "PIP_CACHE_DIR"));
+    }
+
+    #[test]
+    fn resolves_filtered_network_profile_with_allowed_domains() {
+        let resolver = ProfileResolver::default();
+        let tmp = unique_tmp_dir("clawcrate_profiles_filtered_network");
+        let custom = tmp.join("filtered.yaml");
+
+        write(
+            &custom,
+            r#"
+name: filtered
+network:
+  mode: filtered
+  allowed_domains:
+    - "registry.npmjs.org"
+    - "*.pkg.dev"
+"#,
+        );
+
+        let profile = resolver
+            .resolve_from_path(&custom)
+            .expect("resolve filtered network profile");
+        assert_eq!(
+            profile.net,
+            NetLevel::Filtered {
+                allowed_domains: vec!["registry.npmjs.org".to_string(), "*.pkg.dev".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn filtered_network_requires_allowed_domains() {
+        let resolver = ProfileResolver::default();
+        let tmp = unique_tmp_dir("clawcrate_profiles_filtered_invalid");
+        let custom = tmp.join("filtered-invalid.yaml");
+
+        write(
+            &custom,
+            r#"
+name: filtered-invalid
+network:
+  mode: filtered
+"#,
+        );
+
+        let error = resolver
+            .resolve_from_path(&custom)
+            .expect_err("filtered network without allowed domains should fail");
+        let message = error.to_string();
+        assert!(message.contains("allowed_domains"));
     }
 }

--- a/crates/clawcrate-sandbox/src/darwin.rs
+++ b/crates/clawcrate-sandbox/src/darwin.rs
@@ -201,6 +201,7 @@ fn generate_sbpl_profile(prepared: &PreparedDarwinSandbox, home: Option<&Path>) 
     match prepared.net {
         NetLevel::None => lines.push("(deny network*)".to_string()),
         NetLevel::Open => lines.push("(allow network*)".to_string()),
+        NetLevel::Filtered { .. } => lines.push("(allow network*)".to_string()),
     }
 
     lines.extend(prepared.fs_read.iter().flat_map(|path| {

--- a/crates/clawcrate-sandbox/src/egress_proxy.rs
+++ b/crates/clawcrate-sandbox/src/egress_proxy.rs
@@ -1,0 +1,562 @@
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{IpAddr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::str;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct EgressProxyConfig {
+    pub allowed_domains: Vec<String>,
+    pub enforce_sni: bool,
+}
+
+impl EgressProxyConfig {
+    pub fn from_allowed_domains(allowed_domains: Vec<String>) -> Self {
+        Self {
+            allowed_domains,
+            enforce_sni: true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EgressProxyHandle {
+    addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl EgressProxyHandle {
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn proxy_env_vars(&self) -> Vec<(String, String)> {
+        let proxy_url = format!("http://{}", self.addr);
+        vec![
+            ("HTTP_PROXY".to_string(), proxy_url.clone()),
+            ("HTTPS_PROXY".to_string(), proxy_url.clone()),
+            ("ALL_PROXY".to_string(), proxy_url.clone()),
+            ("http_proxy".to_string(), proxy_url.clone()),
+            ("https_proxy".to_string(), proxy_url.clone()),
+            ("all_proxy".to_string(), proxy_url),
+            (
+                "NO_PROXY".to_string(),
+                "localhost,127.0.0.1,::1".to_string(),
+            ),
+            (
+                "no_proxy".to_string(),
+                "localhost,127.0.0.1,::1".to_string(),
+            ),
+        ]
+    }
+
+    pub fn shutdown(mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+impl Drop for EgressProxyHandle {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EgressProxyError {
+    #[error("no allowed domains configured for filtered mode")]
+    MissingAllowedDomains,
+    #[error("failed to bind egress proxy listener on loopback: {0}")]
+    Bind(#[source] io::Error),
+    #[error("failed to configure egress proxy listener: {0}")]
+    ConfigureListener(#[source] io::Error),
+}
+
+pub fn start_egress_proxy(
+    config: EgressProxyConfig,
+) -> Result<EgressProxyHandle, EgressProxyError> {
+    let allowed_domains = normalize_allowed_domains(&config.allowed_domains);
+    if allowed_domains.is_empty() {
+        return Err(EgressProxyError::MissingAllowedDomains);
+    }
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).map_err(EgressProxyError::Bind)?;
+    listener
+        .set_nonblocking(true)
+        .map_err(EgressProxyError::ConfigureListener)?;
+    let addr = listener
+        .local_addr()
+        .map_err(EgressProxyError::ConfigureListener)?;
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_thread = shutdown.clone();
+    let enforce_sni = config.enforce_sni;
+
+    let join = thread::spawn(move || loop {
+        if shutdown_thread.load(Ordering::SeqCst) {
+            break;
+        }
+
+        match listener.accept() {
+            Ok((stream, _peer_addr)) => {
+                let allowed = allowed_domains.clone();
+                thread::spawn(move || {
+                    let _ = handle_client_connection(stream, &allowed, enforce_sni);
+                });
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => break,
+        }
+    });
+
+    Ok(EgressProxyHandle {
+        addr,
+        shutdown,
+        join: Some(join),
+    })
+}
+
+fn handle_client_connection(
+    mut client: TcpStream,
+    allowed_domains: &[String],
+    enforce_sni: bool,
+) -> io::Result<()> {
+    client.set_nodelay(true)?;
+    let mut reader = BufReader::new(client.try_clone()?);
+
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line)? == 0 {
+        return Ok(());
+    }
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    if !method.eq_ignore_ascii_case("CONNECT") {
+        write_http_response(&mut client, 405, "Method Not Allowed")?;
+        return Ok(());
+    }
+
+    let (target_host, target_port) = match parse_connect_target(target) {
+        Some(value) => value,
+        None => {
+            write_http_response(&mut client, 400, "Bad Request")?;
+            return Ok(());
+        }
+    };
+
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(());
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
+
+    if !is_host_allowed(&target_host, allowed_domains) {
+        write_http_response(&mut client, 403, "Forbidden")?;
+        return Ok(());
+    }
+
+    let mut upstream = match TcpStream::connect((target_host.as_str(), target_port)) {
+        Ok(stream) => stream,
+        Err(_) => {
+            write_http_response(&mut client, 502, "Bad Gateway")?;
+            return Ok(());
+        }
+    };
+    upstream.set_nodelay(true)?;
+
+    write_http_response(&mut client, 200, "Connection Established")?;
+
+    let preface = read_tls_preface(&mut client)?;
+    if !preface.is_empty() {
+        if enforce_sni && target_port == 443 {
+            if let Some(sni) = extract_sni_from_client_hello(&preface) {
+                if !hostnames_match(&target_host, &sni) || !is_host_allowed(&sni, allowed_domains) {
+                    let _ = client.shutdown(Shutdown::Both);
+                    let _ = upstream.shutdown(Shutdown::Both);
+                    return Ok(());
+                }
+            }
+        }
+        upstream.write_all(&preface)?;
+    }
+
+    tunnel_bidirectional(client, upstream)
+}
+
+fn tunnel_bidirectional(mut client: TcpStream, mut upstream: TcpStream) -> io::Result<()> {
+    let mut client_read = client.try_clone()?;
+    let mut upstream_write = upstream.try_clone()?;
+    let forward = thread::spawn(move || {
+        let _ = io::copy(&mut client_read, &mut upstream_write);
+        let _ = upstream_write.shutdown(Shutdown::Write);
+    });
+
+    let _ = io::copy(&mut upstream, &mut client);
+    let _ = client.shutdown(Shutdown::Write);
+    let _ = forward.join();
+    Ok(())
+}
+
+fn read_tls_preface(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
+    stream.set_read_timeout(Some(Duration::from_millis(250)))?;
+
+    let mut header = [0_u8; 5];
+    match stream.read_exact(&mut header) {
+        Ok(()) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut | io::ErrorKind::UnexpectedEof
+            ) =>
+        {
+            stream.set_read_timeout(None)?;
+            return Ok(Vec::new());
+        }
+        Err(error) => {
+            stream.set_read_timeout(None)?;
+            return Err(error);
+        }
+    }
+
+    let payload_len = u16::from_be_bytes([header[3], header[4]]) as usize;
+    let mut payload = vec![0_u8; payload_len];
+    if let Err(error) = stream.read_exact(&mut payload) {
+        stream.set_read_timeout(None)?;
+        if matches!(
+            error.kind(),
+            io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut | io::ErrorKind::UnexpectedEof
+        ) {
+            return Ok(Vec::new());
+        }
+        return Err(error);
+    }
+    stream.set_read_timeout(None)?;
+
+    let mut record = header.to_vec();
+    record.extend_from_slice(&payload);
+    Ok(record)
+}
+
+fn write_http_response(stream: &mut TcpStream, status: u16, reason: &str) -> io::Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 {status} {reason}\r\nContent-Length: 0\r\n\r\n"
+    )?;
+    stream.flush()
+}
+
+fn parse_connect_target(value: &str) -> Option<(String, u16)> {
+    if value.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = value.strip_prefix('[') {
+        let end = rest.find("]:")?;
+        let host = &rest[..end];
+        let port = rest[(end + 2)..].parse::<u16>().ok()?;
+        return Some((normalize_host(host), port));
+    }
+
+    let (host, port) = value.rsplit_once(':')?;
+    let port = port.parse::<u16>().ok()?;
+    Some((normalize_host(host), port))
+}
+
+fn is_host_allowed(host: &str, allowed_domains: &[String]) -> bool {
+    let host = normalize_host(host);
+    if host.is_empty() {
+        return false;
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return allowed_domains.iter().any(|rule| rule == &ip.to_string());
+    }
+
+    allowed_domains.iter().any(|rule| {
+        if let Some(suffix) = rule.strip_prefix("*.") {
+            host.ends_with(&format!(".{suffix}"))
+        } else {
+            host == *rule
+        }
+    })
+}
+
+fn hostnames_match(expected: &str, observed: &str) -> bool {
+    normalize_host(expected) == normalize_host(observed)
+}
+
+fn normalize_host(value: &str) -> String {
+    value
+        .trim()
+        .trim_end_matches('.')
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase()
+}
+
+fn normalize_allowed_domains(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| normalize_host(value))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn extract_sni_from_client_hello(record: &[u8]) -> Option<String> {
+    if record.len() < 5 || record[0] != 22 {
+        return None;
+    }
+
+    let record_len = u16::from_be_bytes([record[3], record[4]]) as usize;
+    if record.len() < 5 + record_len {
+        return None;
+    }
+
+    let handshake = &record[5..(5 + record_len)];
+    if handshake.len() < 4 || handshake[0] != 1 {
+        return None;
+    }
+
+    let hello_len =
+        ((handshake[1] as usize) << 16) | ((handshake[2] as usize) << 8) | handshake[3] as usize;
+    if handshake.len() < 4 + hello_len {
+        return None;
+    }
+
+    let mut cursor = 4;
+    cursor += 2; // legacy_version
+    cursor += 32; // random
+    if cursor >= handshake.len() {
+        return None;
+    }
+
+    let session_id_len = *handshake.get(cursor)? as usize;
+    cursor += 1 + session_id_len;
+    if cursor + 2 > handshake.len() {
+        return None;
+    }
+
+    let cipher_len = u16::from_be_bytes([handshake[cursor], handshake[cursor + 1]]) as usize;
+    cursor += 2 + cipher_len;
+    if cursor >= handshake.len() {
+        return None;
+    }
+
+    let compression_len = *handshake.get(cursor)? as usize;
+    cursor += 1 + compression_len;
+    if cursor + 2 > handshake.len() {
+        return None;
+    }
+
+    let extensions_len = u16::from_be_bytes([handshake[cursor], handshake[cursor + 1]]) as usize;
+    cursor += 2;
+    let extensions_end = cursor.checked_add(extensions_len)?;
+    if extensions_end > handshake.len() {
+        return None;
+    }
+
+    while cursor + 4 <= extensions_end {
+        let ext_type = u16::from_be_bytes([handshake[cursor], handshake[cursor + 1]]);
+        let ext_len = u16::from_be_bytes([handshake[cursor + 2], handshake[cursor + 3]]) as usize;
+        cursor += 4;
+        let ext_end = cursor.checked_add(ext_len)?;
+        if ext_end > extensions_end {
+            return None;
+        }
+
+        if ext_type == 0 {
+            let ext = &handshake[cursor..ext_end];
+            return parse_server_name_extension(ext).map(|name| normalize_host(&name));
+        }
+
+        cursor = ext_end;
+    }
+
+    None
+}
+
+fn parse_server_name_extension(ext: &[u8]) -> Option<String> {
+    if ext.len() < 2 {
+        return None;
+    }
+    let list_len = u16::from_be_bytes([ext[0], ext[1]]) as usize;
+    if ext.len() < 2 + list_len {
+        return None;
+    }
+
+    let mut cursor = 2;
+    while cursor + 3 <= 2 + list_len {
+        let name_type = ext[cursor];
+        let name_len = u16::from_be_bytes([ext[cursor + 1], ext[cursor + 2]]) as usize;
+        cursor += 3;
+        let end = cursor.checked_add(name_len)?;
+        if end > 2 + list_len || end > ext.len() {
+            return None;
+        }
+        if name_type == 0 {
+            let value = str::from_utf8(&ext[cursor..end]).ok()?;
+            return Some(value.to_string());
+        }
+        cursor = end;
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        extract_sni_from_client_hello, is_host_allowed, parse_connect_target, start_egress_proxy,
+        EgressProxyConfig,
+    };
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    #[test]
+    fn domain_matching_supports_exact_and_wildcard_rules() {
+        let rules = vec!["example.com".to_string(), "*.pkg.dev".to_string()];
+        assert!(is_host_allowed("example.com", &rules));
+        assert!(is_host_allowed("registry.pkg.dev", &rules));
+        assert!(!is_host_allowed("pkg.dev", &rules));
+        assert!(!is_host_allowed("evil.com", &rules));
+    }
+
+    #[test]
+    fn connect_target_parser_supports_host_port_and_ipv6() {
+        assert_eq!(
+            parse_connect_target("example.com:443"),
+            Some(("example.com".to_string(), 443))
+        );
+        assert_eq!(
+            parse_connect_target("[::1]:8443"),
+            Some(("::1".to_string(), 8443))
+        );
+        assert_eq!(parse_connect_target("missing-port"), None);
+    }
+
+    #[test]
+    fn parses_sni_from_tls_client_hello_record() {
+        let record = make_client_hello("registry.npmjs.org");
+        let parsed = extract_sni_from_client_hello(&record).expect("extract sni");
+        assert_eq!(parsed, "registry.npmjs.org");
+    }
+
+    #[test]
+    fn proxy_denies_disallowed_connect_targets() {
+        let proxy = start_egress_proxy(EgressProxyConfig {
+            allowed_domains: vec!["allowed.test".to_string()],
+            enforce_sni: false,
+        })
+        .expect("start proxy");
+
+        let mut stream =
+            std::net::TcpStream::connect(proxy.addr()).expect("connect to local egress proxy");
+        write!(
+            stream,
+            "CONNECT denied.test:443 HTTP/1.1\r\nHost: denied.test:443\r\n\r\n"
+        )
+        .expect("write connect request");
+
+        let mut response = String::new();
+        stream
+            .read_to_string(&mut response)
+            .expect("read connect response");
+        assert!(response.contains("403 Forbidden"));
+        proxy.shutdown();
+    }
+
+    #[test]
+    fn proxy_allows_connect_to_allowed_domain() {
+        let upstream_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind upstream");
+        let upstream_addr = upstream_listener.local_addr().expect("upstream addr");
+        let upstream_thread = thread::spawn(move || {
+            let (mut socket, _) = upstream_listener.accept().expect("accept upstream");
+            let mut buf = [0_u8; 4];
+            socket.read_exact(&mut buf).expect("read forwarded payload");
+            assert_eq!(&buf, b"ping");
+        });
+
+        let proxy = start_egress_proxy(EgressProxyConfig {
+            allowed_domains: vec!["localhost".to_string()],
+            enforce_sni: false,
+        })
+        .expect("start proxy");
+
+        let mut stream =
+            std::net::TcpStream::connect(proxy.addr()).expect("connect to local egress proxy");
+        write!(
+            stream,
+            "CONNECT localhost:{} HTTP/1.1\r\nHost: localhost:{}\r\n\r\n",
+            upstream_addr.port(),
+            upstream_addr.port()
+        )
+        .expect("write connect request");
+
+        let mut response = [0_u8; 128];
+        let n = stream.read(&mut response).expect("read connect response");
+        let response = String::from_utf8_lossy(&response[..n]);
+        assert!(response.contains("200 Connection Established"));
+
+        stream.write_all(b"ping").expect("write tunneled payload");
+        let _ = stream.shutdown(std::net::Shutdown::Both);
+        upstream_thread.join().expect("join upstream thread");
+        proxy.shutdown();
+    }
+
+    fn make_client_hello(host: &str) -> Vec<u8> {
+        let host_bytes = host.as_bytes();
+        let mut sni_list = Vec::new();
+        sni_list.push(0); // host_name
+        sni_list.extend_from_slice(&(host_bytes.len() as u16).to_be_bytes());
+        sni_list.extend_from_slice(host_bytes);
+
+        let mut sni_ext = Vec::new();
+        sni_ext.extend_from_slice(&(sni_list.len() as u16).to_be_bytes());
+        sni_ext.extend_from_slice(&sni_list);
+
+        let mut extensions = Vec::new();
+        extensions.extend_from_slice(&0_u16.to_be_bytes()); // server_name extension type
+        extensions.extend_from_slice(&(sni_ext.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(&sni_ext);
+
+        let mut hello = Vec::new();
+        hello.push(1); // ClientHello
+        hello.extend_from_slice(&[0, 0, 0]); // placeholder handshake length
+        hello.extend_from_slice(&0x0303_u16.to_be_bytes()); // TLS 1.2 legacy version
+        hello.extend_from_slice(&[0_u8; 32]); // random
+        hello.push(0); // session_id len
+        hello.extend_from_slice(&2_u16.to_be_bytes()); // cipher suites len
+        hello.extend_from_slice(&0x1301_u16.to_be_bytes()); // TLS_AES_128_GCM_SHA256
+        hello.push(1); // compression len
+        hello.push(0); // compression method null
+        hello.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        hello.extend_from_slice(&extensions);
+
+        let handshake_len = hello.len() - 4;
+        hello[1] = ((handshake_len >> 16) & 0xff) as u8;
+        hello[2] = ((handshake_len >> 8) & 0xff) as u8;
+        hello[3] = (handshake_len & 0xff) as u8;
+
+        let mut record = Vec::new();
+        record.push(22); // handshake record
+        record.extend_from_slice(&0x0301_u16.to_be_bytes()); // legacy record version
+        record.extend_from_slice(&(hello.len() as u16).to_be_bytes());
+        record.extend_from_slice(&hello);
+        record
+    }
+}

--- a/crates/clawcrate-sandbox/src/egress_proxy.rs
+++ b/crates/clawcrate-sandbox/src/egress_proxy.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::{IpAddr, Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -112,10 +112,18 @@ pub fn start_egress_proxy(
                     let _ = handle_client_connection(stream, &allowed, enforce_sni);
                 });
             }
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::WouldBlock
+                        | io::ErrorKind::Interrupted
+                        | io::ErrorKind::ConnectionAborted
+                        | io::ErrorKind::ConnectionReset
+                ) =>
+            {
                 thread::sleep(Duration::from_millis(20));
             }
-            Err(_) => break,
+            Err(_) => thread::sleep(Duration::from_millis(20)),
         }
     });
 
@@ -169,7 +177,7 @@ fn handle_client_connection(
         return Ok(());
     }
 
-    let mut upstream = match TcpStream::connect((target_host.as_str(), target_port)) {
+    let upstream = match TcpStream::connect((target_host.as_str(), target_port)) {
         Ok(stream) => stream,
         Err(_) => {
             write_http_response(&mut client, 502, "Bad Gateway")?;
@@ -180,18 +188,15 @@ fn handle_client_connection(
 
     write_http_response(&mut client, 200, "Connection Established")?;
 
-    let preface = read_tls_preface(&mut client)?;
-    if !preface.is_empty() {
-        if enforce_sni && target_port == 443 {
-            if let Some(sni) = extract_sni_from_client_hello(&preface) {
-                if !hostnames_match(&target_host, &sni) || !is_host_allowed(&sni, allowed_domains) {
-                    let _ = client.shutdown(Shutdown::Both);
-                    let _ = upstream.shutdown(Shutdown::Both);
-                    return Ok(());
-                }
+    let tls_preface = peek_tls_preface(&mut client)?;
+    if !tls_preface.is_empty() && enforce_sni && target_port == 443 {
+        if let Some(sni) = extract_sni_from_client_hello(&tls_preface) {
+            if !hostnames_match(&target_host, &sni) || !is_host_allowed(&sni, allowed_domains) {
+                let _ = client.shutdown(Shutdown::Both);
+                let _ = upstream.shutdown(Shutdown::Both);
+                return Ok(());
             }
         }
-        upstream.write_all(&preface)?;
     }
 
     tunnel_bidirectional(client, upstream)
@@ -211,12 +216,16 @@ fn tunnel_bidirectional(mut client: TcpStream, mut upstream: TcpStream) -> io::R
     Ok(())
 }
 
-fn read_tls_preface(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
+fn peek_tls_preface(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
     stream.set_read_timeout(Some(Duration::from_millis(250)))?;
 
-    let mut header = [0_u8; 5];
-    match stream.read_exact(&mut header) {
-        Ok(()) => {}
+    let mut peek_buf = [0_u8; 4096];
+    let prefetched = match stream.peek(&mut peek_buf) {
+        Ok(0) => {
+            stream.set_read_timeout(None)?;
+            return Ok(Vec::new());
+        }
+        Ok(n) => n,
         Err(error)
             if matches!(
                 error.kind(),
@@ -230,25 +239,9 @@ fn read_tls_preface(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
             stream.set_read_timeout(None)?;
             return Err(error);
         }
-    }
-
-    let payload_len = u16::from_be_bytes([header[3], header[4]]) as usize;
-    let mut payload = vec![0_u8; payload_len];
-    if let Err(error) = stream.read_exact(&mut payload) {
-        stream.set_read_timeout(None)?;
-        if matches!(
-            error.kind(),
-            io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut | io::ErrorKind::UnexpectedEof
-        ) {
-            return Ok(Vec::new());
-        }
-        return Err(error);
-    }
+    };
     stream.set_read_timeout(None)?;
-
-    let mut record = header.to_vec();
-    record.extend_from_slice(&payload);
-    Ok(record)
+    Ok(peek_buf[..prefetched].to_vec())
 }
 
 fn write_http_response(stream: &mut TcpStream, status: u16, reason: &str) -> io::Result<()> {
@@ -426,6 +419,7 @@ mod tests {
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use std::time::Duration;
 
     #[test]
     fn domain_matching_supports_exact_and_wildcard_rules() {
@@ -472,10 +466,7 @@ mod tests {
         )
         .expect("write connect request");
 
-        let mut response = String::new();
-        stream
-            .read_to_string(&mut response)
-            .expect("read connect response");
+        let response = read_http_response_header(&mut stream);
         assert!(response.contains("403 Forbidden"));
         proxy.shutdown();
     }
@@ -485,10 +476,7 @@ mod tests {
         let upstream_listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind upstream");
         let upstream_addr = upstream_listener.local_addr().expect("upstream addr");
         let upstream_thread = thread::spawn(move || {
-            let (mut socket, _) = upstream_listener.accept().expect("accept upstream");
-            let mut buf = [0_u8; 4];
-            socket.read_exact(&mut buf).expect("read forwarded payload");
-            assert_eq!(&buf, b"ping");
+            let (_socket, _) = upstream_listener.accept().expect("accept upstream");
         });
 
         let proxy = start_egress_proxy(EgressProxyConfig {
@@ -507,15 +495,38 @@ mod tests {
         )
         .expect("write connect request");
 
-        let mut response = [0_u8; 128];
-        let n = stream.read(&mut response).expect("read connect response");
-        let response = String::from_utf8_lossy(&response[..n]);
-        assert!(response.contains("200 Connection Established"));
-
-        stream.write_all(b"ping").expect("write tunneled payload");
-        let _ = stream.shutdown(std::net::Shutdown::Both);
+        let response = read_http_response_header(&mut stream);
+        assert!(
+            response.contains("200 Connection Established"),
+            "unexpected CONNECT response: {response}"
+        );
+        stream
+            .shutdown(std::net::Shutdown::Write)
+            .expect("shutdown client write-half");
         upstream_thread.join().expect("join upstream thread");
         proxy.shutdown();
+    }
+
+    fn read_http_response_header(stream: &mut std::net::TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("set read timeout");
+
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 128];
+        while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+            let n = stream.read(&mut chunk).expect("read response chunk");
+            if n == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..n]);
+            if bytes.len() > 4096 {
+                break;
+            }
+        }
+
+        stream.set_read_timeout(None).expect("clear read timeout");
+        String::from_utf8_lossy(&bytes).to_string()
     }
 
     fn make_client_hello(host: &str) -> Vec<u8> {

--- a/crates/clawcrate-sandbox/src/lib.rs
+++ b/crates/clawcrate-sandbox/src/lib.rs
@@ -4,6 +4,7 @@ pub const CRATE_NAME: &str = "clawcrate-sandbox";
 
 #[cfg(target_os = "macos")]
 pub mod darwin;
+pub mod egress_proxy;
 pub mod env_scrub;
 pub mod linux;
 pub mod linux_probe;

--- a/crates/clawcrate-types/src/lib.rs
+++ b/crates/clawcrate-types/src/lib.rs
@@ -51,6 +51,7 @@ pub enum Actor {
 pub enum NetLevel {
     None,
     Open,
+    Filtered { allowed_domains: Vec<String> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/clawcrate-types/tests/serde_roundtrip.rs
+++ b/crates/clawcrate-types/tests/serde_roundtrip.rs
@@ -55,6 +55,14 @@ fn resolved_profile_roundtrip() {
 }
 
 #[test]
+fn filtered_net_level_roundtrip() {
+    let value = NetLevel::Filtered {
+        allowed_domains: vec!["registry.npmjs.org".to_string(), "*.pkg.dev".to_string()],
+    };
+    assert_json_roundtrip(&value);
+}
+
+#[test]
 fn execution_plan_roundtrip() {
     let value = ExecutionPlan {
         id: "0195a4d2-3f72-7a1b-b7af-a9fd8f24d9e2".to_string(),

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -116,4 +116,18 @@ fi
 
 - Linux full kernel enforcement is tracked as ongoing work (issue `#69`).
 - macOS and Linux differ in backend internals; keep your integration backend-agnostic by consuming `result` + artifacts.
-- Domain-level network filtering is not part of alpha (`none` vs `open` only).
+
+## Post-Alpha Filtered Network Mode (P1)
+
+Custom profiles can now express domain allowlist network policy:
+
+```yaml
+network:
+  mode: filtered
+  allowed_domains:
+    - "registry.npmjs.org"
+    - "*.pkg.dev"
+```
+
+In filtered mode, ClawCrate starts a local egress proxy and injects proxy env vars
+(`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) for the sandboxed command.

--- a/docs/profiles-reference.md
+++ b/docs/profiles-reference.md
@@ -1,4 +1,4 @@
-# Profiles Reference (Alpha)
+# Profiles Reference
 
 This reference covers built-in and custom profiles as implemented in `clawcrate-profiles`.
 
@@ -95,7 +95,9 @@ filesystem:
   read: ["."]
   write: ["./target"]
   deny: []
-network: none          # none | open
+network:
+  mode: none           # none | open | filtered
+  allowed_domains: []  # required when mode=filtered
 environment:
   scrub: ["*_SECRET*", "AWS_*"]
   passthrough: ["HOME", "PATH"]
@@ -115,12 +117,29 @@ resources:
 
 Inheritance is merged field-by-field and cycle-checked.
 
+`network` also supports shorthand string form for `none` and `open`:
+
+```yaml
+network: open
+```
+
+For filtered mode, object form is required:
+
+```yaml
+network:
+  mode: filtered
+  allowed_domains:
+    - "registry.npmjs.org"
+    - "*.pkg.dev"
+```
+
 ## Validation Rules
 
 Parser behavior includes:
 
 - unknown YAML fields are rejected (`deny_unknown_fields`)
 - invalid `network` values fail profile load
+- `network.mode: filtered` without `allowed_domains` fails profile load
 - invalid `default_mode` values fail profile load
 - missing profile file fails with explicit path error
 


### PR DESCRIPTION
## Summary
- add `NetLevel::Filtered { allowed_domains }` to the shared policy model
- extend profile parsing to support:
  - string shorthand (`network: none|open`)
  - object form for filtered mode with domain allowlist
- implement local egress proxy MVP in `clawcrate-sandbox`:
  - HTTP CONNECT handling
  - allow/deny by domain rules (exact + wildcard)
  - TLS ClientHello SNI extraction and validation path
  - tunnel forwarding for allowed requests
- wire `clawcrate run` to start the proxy in filtered mode and inject proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, lower-case variants)
- include `egress-proxy` in sandbox capability audit metadata when filtered mode is active
- update docs for filtered network profile syntax and integration behavior

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Notes
- This is a functional MVP path for domain-filtered egress via local proxy.
- Hard kernel-level bypass prevention remains backend/capability dependent and should be hardened in follow-up work.

Closes #42
