### PR TITLE
feat(p1-04): add community profile catalog validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ See [docs/WORKFLOW.md](docs/WORKFLOW.md) for the operational issue-to-PR workflo
 See [CHANGELOG.md](CHANGELOG.md) for release notes and version history.
 See [docs/release-checklist.md](docs/release-checklist.md) for the alpha release and tagging runbook.
 See [docs/egress-proxy-threat-model.md](docs/egress-proxy-threat-model.md) for the post-alpha network-filtering design baseline.
+See [docs/community-profiles.md](docs/community-profiles.md) for the community profile catalog schema and contribution workflow.
 See [docs/architecture.md](docs/architecture.md), [docs/profiles-reference.md](docs/profiles-reference.md), [docs/kernel-requirements.md](docs/kernel-requirements.md), and [docs/integration-guide.md](docs/integration-guide.md) for the alpha technical docs pack.
 
 ## License

--- a/crates/clawcrate-profiles/src/lib.rs
+++ b/crates/clawcrate-profiles/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use clawcrate_types::{DefaultMode, NetLevel, ResolvedProfile, ResourceLimits};
 use serde::Deserialize;
@@ -39,8 +39,36 @@ pub enum ProfileError {
     InvalidFilteredNetwork { path: PathBuf, reason: String },
     #[error("invalid default_mode value in {path}: {value}")]
     InvalidDefaultMode { path: PathBuf, value: String },
+    #[error("failed to parse community catalog {path}: {source}")]
+    ParseCatalog {
+        path: PathBuf,
+        #[source]
+        source: serde_yaml::Error,
+    },
+    #[error("invalid community catalog in {path}: {reason}")]
+    InvalidCatalog { path: PathBuf, reason: String },
     #[error("cyclic profile inheritance detected at {0}")]
     InheritanceCycle(String),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommunityCatalog {
+    pub version: u32,
+    #[serde(default)]
+    pub profiles: Vec<CommunityCatalogEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommunityCatalogEntry {
+    pub id: String,
+    pub title: String,
+    pub path: PathBuf,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +95,10 @@ impl ProfileResolver {
 
     pub fn profiles_dir(&self) -> &Path {
         &self.profiles_dir
+    }
+
+    pub fn community_catalog_path(&self) -> PathBuf {
+        self.profiles_dir.join("community").join("catalog.yaml")
     }
 
     pub fn resolve(&self, profile: &str) -> Result<ResolvedProfile, ProfileError> {
@@ -108,6 +140,93 @@ impl ProfileResolver {
         };
         apply_stack_overrides(&mut resolved, stack);
         Ok(resolved)
+    }
+
+    pub fn load_community_catalog(
+        &self,
+        catalog_path: impl AsRef<Path>,
+    ) -> Result<CommunityCatalog, ProfileError> {
+        let path = catalog_path.as_ref();
+        let content = fs::read_to_string(path).map_err(|source| ProfileError::ReadFile {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+        serde_yaml::from_str(&content).map_err(|source| ProfileError::ParseCatalog {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
+
+    pub fn validate_community_catalog(
+        &self,
+        catalog_path: impl AsRef<Path>,
+    ) -> Result<usize, ProfileError> {
+        let catalog_path = catalog_path.as_ref();
+        let catalog = self.load_community_catalog(catalog_path)?;
+        if catalog.version != 1 {
+            return Err(ProfileError::InvalidCatalog {
+                path: catalog_path.to_path_buf(),
+                reason: format!("unsupported version {}; expected 1", catalog.version),
+            });
+        }
+
+        let catalog_dir = catalog_path.parent().unwrap_or_else(|| Path::new("."));
+        let mut seen_ids = HashSet::new();
+        let mut seen_paths = HashSet::new();
+
+        for entry in &catalog.profiles {
+            let normalized_id = normalize_string(&entry.id);
+            if entry.id != normalized_id || !is_valid_catalog_id(&entry.id) {
+                return Err(ProfileError::InvalidCatalog {
+                    path: catalog_path.to_path_buf(),
+                    reason: format!(
+                        "entry id '{}' must be lowercase kebab-case [a-z0-9-]",
+                        entry.id
+                    ),
+                });
+            }
+            if !seen_ids.insert(entry.id.clone()) {
+                return Err(ProfileError::InvalidCatalog {
+                    path: catalog_path.to_path_buf(),
+                    reason: format!("duplicate entry id '{}'", entry.id),
+                });
+            }
+            if entry.path.is_absolute() {
+                return Err(ProfileError::InvalidCatalog {
+                    path: catalog_path.to_path_buf(),
+                    reason: format!("entry '{}' path must be relative", entry.id),
+                });
+            }
+            if entry
+                .path
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+            {
+                return Err(ProfileError::InvalidCatalog {
+                    path: catalog_path.to_path_buf(),
+                    reason: format!("entry '{}' path cannot escape catalog directory", entry.id),
+                });
+            }
+            if entry.path.extension().and_then(|it| it.to_str()) != Some("yaml") {
+                return Err(ProfileError::InvalidCatalog {
+                    path: catalog_path.to_path_buf(),
+                    reason: format!("entry '{}' path must end in .yaml", entry.id),
+                });
+            }
+            let path_key = entry.path.to_string_lossy().to_string();
+            if !seen_paths.insert(path_key) {
+                return Err(ProfileError::InvalidCatalog {
+                    path: catalog_path.to_path_buf(),
+                    reason: format!("duplicate profile path '{}'", entry.path.display()),
+                });
+            }
+
+            let profile_path = catalog_dir.join(&entry.path);
+            self.resolve_from_path(&profile_path)?;
+        }
+
+        Ok(catalog.profiles.len())
     }
 
     fn resolve_entry(
@@ -432,6 +551,20 @@ fn normalize_allowed_domains(values: &[String]) -> Vec<String> {
         .collect()
 }
 
+fn is_valid_catalog_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    if bytes[0] == b'-' || bytes[bytes.len() - 1] == b'-' {
+        return false;
+    }
+
+    bytes
+        .iter()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
+}
+
 fn looks_like_path(reference: &str) -> bool {
     reference.ends_with(".yaml")
         || reference.ends_with(".yml")
@@ -750,5 +883,79 @@ network:
             .expect_err("filtered network without allowed domains should fail");
         let message = error.to_string();
         assert!(message.contains("allowed_domains"));
+    }
+
+    #[test]
+    fn validates_repository_community_catalog() {
+        let resolver = ProfileResolver::default();
+        let count = resolver
+            .validate_community_catalog(resolver.community_catalog_path())
+            .expect("validate bundled community catalog");
+        assert!(count >= 1);
+    }
+
+    #[test]
+    fn rejects_catalog_entry_with_parent_directory_escape() {
+        let resolver = ProfileResolver::default();
+        let tmp = unique_tmp_dir("clawcrate_profiles_catalog_path_escape");
+        let catalog = tmp.join("catalog.yaml");
+
+        write(
+            &catalog,
+            r#"
+version: 1
+profiles:
+  - id: escaped-entry
+    title: Escaped
+    path: ../outside.yaml
+"#,
+        );
+
+        let error = resolver
+            .validate_community_catalog(&catalog)
+            .expect_err("catalog path escape should fail");
+        assert!(error.to_string().contains("cannot escape"));
+    }
+
+    #[test]
+    fn rejects_catalog_entry_with_duplicate_id() {
+        let resolver = ProfileResolver::default();
+        let tmp = unique_tmp_dir("clawcrate_profiles_catalog_duplicate_id");
+        let catalog = tmp.join("catalog.yaml");
+        let first = tmp.join("one.yaml");
+        let second = tmp.join("two.yaml");
+
+        write(
+            &first,
+            r#"
+name: one
+extends: safe
+"#,
+        );
+        write(
+            &second,
+            r#"
+name: two
+extends: safe
+"#,
+        );
+        write(
+            &catalog,
+            r#"
+version: 1
+profiles:
+  - id: duplicate
+    title: One
+    path: one.yaml
+  - id: duplicate
+    title: Two
+    path: two.yaml
+"#,
+        );
+
+        let error = resolver
+            .validate_community_catalog(&catalog)
+            .expect_err("duplicate catalog id should fail");
+        assert!(error.to_string().contains("duplicate entry id"));
     }
 }

--- a/docs/community-profiles.md
+++ b/docs/community-profiles.md
@@ -1,0 +1,72 @@
+# Community Profile Catalog
+
+This document defines how community-maintained profiles are organized, validated, and reviewed.
+
+## Repository Structure
+
+Community profiles live under `profiles/community/`:
+
+```text
+profiles/community/
+├── catalog.yaml
+├── npm-install-allowlist.yaml
+└── pip-install-pypi-only.yaml
+```
+
+`catalog.yaml` is the source of truth for discoverable community profiles.
+
+## Catalog Schema
+
+`catalog.yaml` must follow this structure:
+
+```yaml
+version: 1
+profiles:
+  - id: npm-install-allowlist
+    title: npm install with minimal registry allowlist
+    path: npm-install-allowlist.yaml
+    owner: "@clawcrate-community"
+    tags: [node, install, filtered-network]
+```
+
+Rules enforced by `clawcrate-profiles` validation:
+
+- `version` must be `1`.
+- `id` must be lowercase kebab-case (`[a-z0-9-]`).
+- `id` values must be unique.
+- `path` must be a relative `.yaml` file inside `profiles/community/`.
+- `path` values must be unique.
+- Every listed profile must parse through the same strict profile schema as built-ins.
+
+## Profile Schema Validation
+
+Each community profile is validated by the same parser as built-in profiles:
+
+- unknown keys are rejected (`deny_unknown_fields`)
+- invalid `default_mode`, `network`, and filtered `allowed_domains` combinations fail
+- inheritance (`extends`) is resolved and cycle-checked
+
+Validation is executed in CI by `cargo test --workspace` through tests in `clawcrate-profiles`.
+
+## Contribution Flow
+
+1. Add or update profile YAML in `profiles/community/`.
+2. Add/update entry in `profiles/community/catalog.yaml`.
+3. Run local checks:
+   - `cargo fmt --all`
+   - `cargo clippy --workspace --all-targets -- -D warnings`
+   - `cargo test --workspace`
+4. Open PR with:
+   - threat model note (what risk is reduced)
+   - scope note (who should use this profile)
+   - validation output (tests passing)
+
+## Review Checklist
+
+Maintainers should verify:
+
+- the profile grants least privilege for filesystem + network
+- filtered network domains are minimal and justified
+- replica/direct default is aligned with risk level
+- env scrub/pass-through values avoid secret leakage
+- profile naming and metadata in catalog remain clear and searchable

--- a/docs/profiles-reference.md
+++ b/docs/profiles-reference.md
@@ -133,6 +133,20 @@ network:
     - "*.pkg.dev"
 ```
 
+## Community Profile Catalog
+
+Community-maintained profiles are stored in `profiles/community/` and indexed by
+`profiles/community/catalog.yaml`.
+
+Catalog entries are schema-validated by `clawcrate-profiles` with these rules:
+
+- catalog version must be `1`
+- ids are lowercase kebab-case and unique
+- paths are relative `.yaml` files under `profiles/community/`
+- each listed profile resolves through the same strict profile parser used by built-ins
+
+Contribution and review flow is documented in [docs/community-profiles.md](community-profiles.md).
+
 ## Validation Rules
 
 Parser behavior includes:

--- a/profiles/community/catalog.yaml
+++ b/profiles/community/catalog.yaml
@@ -1,0 +1,18 @@
+version: 1
+profiles:
+  - id: npm-install-allowlist
+    title: npm install with minimal registry allowlist
+    path: npm-install-allowlist.yaml
+    owner: "@clawcrate-community"
+    tags:
+      - node
+      - install
+      - filtered-network
+  - id: pip-install-pypi-only
+    title: pip install restricted to PyPI domains
+    path: pip-install-pypi-only.yaml
+    owner: "@clawcrate-community"
+    tags:
+      - python
+      - install
+      - filtered-network

--- a/profiles/community/npm-install-allowlist.yaml
+++ b/profiles/community/npm-install-allowlist.yaml
@@ -1,0 +1,26 @@
+name: npm-install-allowlist
+extends: install
+filesystem:
+  read:
+    - "."
+    - "~/.npm"
+    - "~/.pnpm-store"
+  write:
+    - "./node_modules"
+    - "./package-lock.json"
+    - "./pnpm-lock.yaml"
+    - "~/.npm"
+    - "~/.pnpm-store"
+network:
+  mode: filtered
+  allowed_domains:
+    - registry.npmjs.org
+    - registry.yarnpkg.com
+    - "*.pkg.dev"
+environment:
+  scrub:
+    - "*_TOKEN*"
+    - "NPM_TOKEN"
+  passthrough:
+    - HOME
+    - PATH

--- a/profiles/community/pip-install-pypi-only.yaml
+++ b/profiles/community/pip-install-pypi-only.yaml
@@ -1,0 +1,24 @@
+name: pip-install-pypi-only
+extends: install
+filesystem:
+  read:
+    - "."
+    - "~/.cache/pip"
+  write:
+    - "./.venv"
+    - "./requirements.txt"
+    - "./requirements.lock"
+    - "~/.cache/pip"
+network:
+  mode: filtered
+  allowed_domains:
+    - pypi.org
+    - files.pythonhosted.org
+environment:
+  scrub:
+    - "PIP_INDEX_URL"
+    - "PIP_EXTRA_INDEX_URL"
+    - "*_TOKEN*"
+  passthrough:
+    - HOME
+    - PATH


### PR DESCRIPTION
## Summary
- add profiles/community with a versioned catalog and initial example profiles
- add strict community catalog validation in clawcrate-profiles (id/path/version/uniqueness + profile resolution)
- document catalog schema and maintainer review flow

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #44