### PR TITLE
feat(p2-01): add optional sqlite audit indexing layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +207,7 @@ version = "0.1.0-alpha.0"
 dependencies = [
  "chrono",
  "clawcrate-types",
+ "rusqlite",
  "serde",
  "serde_json",
  "thiserror",
@@ -389,6 +402,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +463,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -450,6 +484,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -550,6 +593,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +757,20 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustix"
@@ -932,6 +1006,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1231,6 +1311,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/clawcrate-audit/Cargo.toml
+++ b/crates/clawcrate-audit/Cargo.toml
@@ -10,10 +10,9 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 clawcrate-types = { path = "../clawcrate-types" }
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde = "1"
 serde_json = "1"
 thiserror = "2"
-
-[dev-dependencies]
-chrono = { version = "0.4", features = ["serde"] }

--- a/crates/clawcrate-audit/src/lib.rs
+++ b/crates/clawcrate-audit/src/lib.rs
@@ -5,6 +5,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use clawcrate_types::{AuditEvent, ExecutionPlan, ExecutionResult};
+use rusqlite::{params, Connection};
 use serde::Serialize;
 
 pub const CRATE_NAME: &str = "clawcrate-audit";
@@ -12,6 +13,7 @@ pub const PLAN_JSON: &str = "plan.json";
 pub const RESULT_JSON: &str = "result.json";
 pub const AUDIT_NDJSON: &str = "audit.ndjson";
 pub const FS_DIFF_JSON: &str = "fs-diff.json";
+pub const DEFAULT_AUDIT_DB: &str = "audit-index.sqlite3";
 
 #[derive(Debug, Clone)]
 pub struct ArtifactWriter {
@@ -148,6 +150,340 @@ fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), ArtifactW
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SqliteIndexedRun {
+    pub execution_id: String,
+    pub has_result: bool,
+    pub event_count: usize,
+}
+
+#[derive(Debug)]
+pub struct SqliteAuditIndex {
+    db_path: PathBuf,
+    connection: Connection,
+}
+
+impl SqliteAuditIndex {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, SqliteAuditIndexError> {
+        let db_path = path.as_ref().to_path_buf();
+        if let Some(parent) = db_path.parent() {
+            fs::create_dir_all(parent).map_err(|source| {
+                SqliteAuditIndexError::CreateParentDir {
+                    path: parent.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+
+        let connection =
+            Connection::open(&db_path).map_err(|source| SqliteAuditIndexError::OpenDatabase {
+                path: db_path.clone(),
+                source,
+            })?;
+
+        connection.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             PRAGMA journal_mode = WAL;
+             CREATE TABLE IF NOT EXISTS executions (
+               execution_id TEXT PRIMARY KEY,
+               created_at TEXT NOT NULL,
+               command_json TEXT NOT NULL,
+               cwd TEXT NOT NULL,
+               profile_name TEXT NOT NULL,
+               mode_json TEXT NOT NULL,
+               net_json TEXT NOT NULL,
+               artifacts_dir TEXT,
+               status TEXT,
+               status_detail TEXT,
+               exit_code INTEGER,
+               duration_ms INTEGER,
+               indexed_at TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS audit_events (
+               execution_id TEXT NOT NULL,
+               sequence INTEGER NOT NULL,
+               timestamp TEXT NOT NULL,
+               event_kind TEXT NOT NULL,
+               payload_json TEXT NOT NULL,
+               PRIMARY KEY(execution_id, sequence),
+               FOREIGN KEY(execution_id) REFERENCES executions(execution_id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_audit_events_kind ON audit_events(event_kind);
+             CREATE INDEX IF NOT EXISTS idx_audit_events_ts ON audit_events(execution_id, timestamp);",
+        )
+        .map_err(|source| SqliteAuditIndexError::MigrateDatabase {
+            path: db_path.clone(),
+            source,
+        })?;
+
+        Ok(Self {
+            db_path,
+            connection,
+        })
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub fn index_artifacts_dir(
+        &mut self,
+        artifacts_dir: &Path,
+    ) -> Result<SqliteIndexedRun, SqliteAuditIndexError> {
+        let plan_path = artifacts_dir.join(PLAN_JSON);
+        let result_path = artifacts_dir.join(RESULT_JSON);
+        let audit_path = artifacts_dir.join(AUDIT_NDJSON);
+
+        let plan: ExecutionPlan = read_json_file(&plan_path)?;
+        let result = if result_path.exists() {
+            Some(read_json_file::<ExecutionResult>(&result_path)?)
+        } else {
+            None
+        };
+        let audit_events = read_ndjson_audit_events(&audit_path)?;
+
+        let mode_json = serde_json::to_string(&plan.mode).map_err(|source| {
+            SqliteAuditIndexError::Serialize {
+                path: plan_path.clone(),
+                source,
+            }
+        })?;
+        let net_json = serde_json::to_string(&plan.profile.net).map_err(|source| {
+            SqliteAuditIndexError::Serialize {
+                path: plan_path.clone(),
+                source,
+            }
+        })?;
+        let command_json = serde_json::to_string(&plan.command).map_err(|source| {
+            SqliteAuditIndexError::Serialize {
+                path: plan_path.clone(),
+                source,
+            }
+        })?;
+
+        let (status, status_detail, exit_code, duration_ms, artifacts_dir_value) = match &result {
+            Some(value) => {
+                let (status_label, detail) = result_status_columns(&value.status);
+                (
+                    Some(status_label),
+                    detail,
+                    value.exit_code,
+                    Some(value.duration_ms as i64),
+                    Some(value.artifacts_dir.display().to_string()),
+                )
+            }
+            None => (None, None, None, None, None),
+        };
+
+        let tx = self.connection.transaction().map_err(|source| {
+            SqliteAuditIndexError::WriteDatabase {
+                path: self.db_path.clone(),
+                source,
+            }
+        })?;
+
+        tx.execute(
+            "INSERT INTO executions (
+               execution_id, created_at, command_json, cwd, profile_name, mode_json, net_json,
+               artifacts_dir, status, status_detail, exit_code, duration_ms, indexed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+             ON CONFLICT(execution_id) DO UPDATE SET
+               created_at=excluded.created_at,
+               command_json=excluded.command_json,
+               cwd=excluded.cwd,
+               profile_name=excluded.profile_name,
+               mode_json=excluded.mode_json,
+               net_json=excluded.net_json,
+               artifacts_dir=excluded.artifacts_dir,
+               status=excluded.status,
+               status_detail=excluded.status_detail,
+               exit_code=excluded.exit_code,
+               duration_ms=excluded.duration_ms,
+               indexed_at=excluded.indexed_at",
+            params![
+                plan.id,
+                plan.created_at.to_rfc3339(),
+                command_json,
+                plan.cwd.display().to_string(),
+                plan.profile.name,
+                mode_json,
+                net_json,
+                artifacts_dir_value,
+                status,
+                status_detail,
+                exit_code,
+                duration_ms,
+                chrono::Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(|source| SqliteAuditIndexError::WriteDatabase {
+            path: self.db_path.clone(),
+            source,
+        })?;
+
+        tx.execute(
+            "DELETE FROM audit_events WHERE execution_id = ?1",
+            params![plan.id],
+        )
+        .map_err(|source| SqliteAuditIndexError::WriteDatabase {
+            path: self.db_path.clone(),
+            source,
+        })?;
+
+        for (sequence, event) in audit_events.iter().enumerate() {
+            let payload_json = serde_json::to_string(event).map_err(|source| {
+                SqliteAuditIndexError::Serialize {
+                    path: audit_path.clone(),
+                    source,
+                }
+            })?;
+            tx.execute(
+                "INSERT INTO audit_events (
+                   execution_id, sequence, timestamp, event_kind, payload_json
+                 ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    plan.id,
+                    sequence as i64,
+                    event.timestamp.to_rfc3339(),
+                    audit_event_kind_label(&event.event),
+                    payload_json
+                ],
+            )
+            .map_err(|source| SqliteAuditIndexError::WriteDatabase {
+                path: self.db_path.clone(),
+                source,
+            })?;
+        }
+
+        tx.commit()
+            .map_err(|source| SqliteAuditIndexError::WriteDatabase {
+                path: self.db_path.clone(),
+                source,
+            })?;
+
+        Ok(SqliteIndexedRun {
+            execution_id: plan.id,
+            has_result: result.is_some(),
+            event_count: audit_events.len(),
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SqliteAuditIndexError {
+    #[error("failed to create SQLite parent directory {path}: {source}")]
+    CreateParentDir {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to open SQLite index at {path}: {source}")]
+    OpenDatabase {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("failed to migrate SQLite index at {path}: {source}")]
+    MigrateDatabase {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("failed to write SQLite index at {path}: {source}")]
+    WriteDatabase {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("failed to read artifact file {path}: {source}")]
+    ReadArtifact {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to parse JSON artifact {path}: {source}")]
+    ParseJson {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to parse audit event line {line} in {path}: {source}")]
+    ParseNdjsonLine {
+        path: PathBuf,
+        line: usize,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to serialize index payload for {path}: {source}")]
+    Serialize {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+fn read_json_file<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, SqliteAuditIndexError> {
+    let content =
+        fs::read_to_string(path).map_err(|source| SqliteAuditIndexError::ReadArtifact {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    serde_json::from_str(&content).map_err(|source| SqliteAuditIndexError::ParseJson {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn read_ndjson_audit_events(path: &Path) -> Result<Vec<AuditEvent>, SqliteAuditIndexError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content =
+        fs::read_to_string(path).map_err(|source| SqliteAuditIndexError::ReadArtifact {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let mut events = Vec::new();
+    for (index, line) in content.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str::<AuditEvent>(line).map_err(|source| {
+            SqliteAuditIndexError::ParseNdjsonLine {
+                path: path.to_path_buf(),
+                line: index + 1,
+                source,
+            }
+        })?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+fn result_status_columns(status: &clawcrate_types::Status) -> (&'static str, Option<String>) {
+    match status {
+        clawcrate_types::Status::Success => ("success", None),
+        clawcrate_types::Status::Failed => ("failed", None),
+        clawcrate_types::Status::Timeout => ("timeout", None),
+        clawcrate_types::Status::Killed => ("killed", None),
+        clawcrate_types::Status::SandboxError(reason) => ("sandbox_error", Some(reason.clone())),
+    }
+}
+
+fn audit_event_kind_label(event: &clawcrate_types::AuditEventKind) -> &'static str {
+    match event {
+        clawcrate_types::AuditEventKind::SandboxApplied { .. } => "sandbox_applied",
+        clawcrate_types::AuditEventKind::EnvScrubbed { .. } => "env_scrubbed",
+        clawcrate_types::AuditEventKind::ProcessStarted { .. } => "process_started",
+        clawcrate_types::AuditEventKind::ProcessExited { .. } => "process_exited",
+        clawcrate_types::AuditEventKind::PermissionBlocked { .. } => "permission_blocked",
+        clawcrate_types::AuditEventKind::ReplicaCreated { .. } => "replica_created",
+        clawcrate_types::AuditEventKind::ReplicaSyncBack { .. } => "replica_sync_back",
+        clawcrate_types::AuditEventKind::ApprovalDecision { .. } => "approval_decision",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -159,9 +495,12 @@ mod tests {
         Actor, AuditEvent, AuditEventKind, DefaultMode, ExecutionPlan, ExecutionResult, NetLevel,
         ResolvedProfile, ResourceLimits, Status, WorkspaceMode,
     };
+    use rusqlite::Connection;
     use serde::{Deserialize, Serialize};
 
-    use super::{ArtifactWriter, AUDIT_NDJSON, FS_DIFF_JSON, PLAN_JSON, RESULT_JSON};
+    use super::{
+        ArtifactWriter, SqliteAuditIndex, AUDIT_NDJSON, FS_DIFF_JSON, PLAN_JSON, RESULT_JSON,
+    };
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
     struct FsDiffFixture {
@@ -303,5 +642,70 @@ mod tests {
             parsed2.event,
             AuditEventKind::ProcessStarted { .. }
         ));
+    }
+
+    #[test]
+    fn sqlite_indexer_upserts_run_and_events_from_artifacts() {
+        let root = unique_tmp_dir("clawcrate_audit_sqlite_index");
+        let writer = ArtifactWriter::new(&root, "exec-001").expect("create writer");
+        let plan = test_plan();
+        let result = test_result();
+
+        writer.write_plan(&plan).expect("write plan");
+        writer.write_result(&result).expect("write result");
+        writer
+            .append_audit_event(&AuditEvent {
+                timestamp: Utc::now(),
+                event: AuditEventKind::SandboxApplied {
+                    backend: "linux".to_string(),
+                    capabilities: vec!["landlock".to_string(), "seccomp".to_string()],
+                },
+            })
+            .expect("append event 1");
+        writer
+            .append_audit_event(&AuditEvent {
+                timestamp: Utc::now(),
+                event: AuditEventKind::ProcessExited {
+                    exit_code: 0,
+                    duration_ms: 55,
+                },
+            })
+            .expect("append event 2");
+
+        let db_path = root.join("audit-index.sqlite3");
+        let mut index = SqliteAuditIndex::open(&db_path).expect("open sqlite index");
+        let indexed = index
+            .index_artifacts_dir(writer.artifacts_dir())
+            .expect("index artifacts");
+        assert_eq!(indexed.execution_id, plan.id);
+        assert!(indexed.has_result);
+        assert_eq!(indexed.event_count, 2);
+
+        let conn = Connection::open(db_path).expect("open sqlite db");
+        let (profile_name, status, event_count): (String, String, i64) = conn
+            .query_row(
+                "SELECT profile_name, status, (SELECT COUNT(*) FROM audit_events WHERE execution_id = executions.execution_id) FROM executions WHERE execution_id = ?1",
+                [plan.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("query indexed execution");
+        assert_eq!(profile_name, "safe");
+        assert_eq!(status, "success");
+        assert_eq!(event_count, 2);
+    }
+
+    #[test]
+    fn sqlite_indexer_accepts_missing_result_and_audit_files() {
+        let root = unique_tmp_dir("clawcrate_audit_sqlite_partial");
+        let writer = ArtifactWriter::new(&root, "exec-002").expect("create writer");
+        writer.write_plan(&test_plan()).expect("write plan");
+
+        let db_path = root.join("audit-index.sqlite3");
+        let mut index = SqliteAuditIndex::open(&db_path).expect("open sqlite index");
+        let indexed = index
+            .index_artifacts_dir(writer.artifacts_dir())
+            .expect("index artifacts");
+        assert!(!indexed.has_result);
+        assert_eq!(indexed.event_count, 0);
     }
 }

--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, Result};
 use chrono::Utc;
 use clap::{ArgAction, Args, Parser, Subcommand};
-use clawcrate_audit::ArtifactWriter;
+use clawcrate_audit::{ArtifactWriter, SqliteAuditIndex, DEFAULT_AUDIT_DB};
 use clawcrate_capture::{
     capture_streams, diff_snapshots, snapshot_paths, CaptureConfig, CaptureError, CaptureSummary,
     FsChange, FsChangeKind,
@@ -260,6 +260,7 @@ fn handle_run(resolver: &ProfileResolver, args: CommandArgs, output: &OutputOpti
     let cwd =
         std::env::current_dir().map_err(|source| anyhow!("failed to get current dir: {source}"))?;
     let plan = build_execution_plan(resolver, &cwd, &args)?;
+    let mut sqlite_index = configure_optional_sqlite_index(output);
     verbose_log(
         output,
         1,
@@ -291,6 +292,7 @@ fn handle_run(resolver: &ProfileResolver, args: CommandArgs, output: &OutputOpti
             started_at.elapsed().as_millis() as u64,
             &error,
         )?;
+        maybe_index_artifacts_in_sqlite(&mut sqlite_index, &writer, output);
         return Err(error);
     }
 
@@ -303,6 +305,7 @@ fn handle_run(resolver: &ProfileResolver, args: CommandArgs, output: &OutputOpti
                 started_at.elapsed().as_millis() as u64,
                 &error,
             )?;
+            maybe_index_artifacts_in_sqlite(&mut sqlite_index, &writer, output);
             return Err(error);
         }
     };
@@ -334,6 +337,7 @@ fn handle_run(resolver: &ProfileResolver, args: CommandArgs, output: &OutputOpti
     writer
         .write_result(&result)
         .map_err(|source| anyhow!("failed to write result artifact: {source}"))?;
+    maybe_index_artifacts_in_sqlite(&mut sqlite_index, &writer, output);
 
     let summary = RunSummary {
         result,
@@ -832,12 +836,78 @@ fn apply_replica_sync_back(
 }
 
 fn runs_root() -> Result<PathBuf> {
+    Ok(clawcrate_home_root()?.join("runs"))
+}
+
+fn clawcrate_home_root() -> Result<PathBuf> {
     if let Some(home) = std::env::var_os("HOME") {
-        return Ok(PathBuf::from(home).join(".clawcrate").join("runs"));
+        return Ok(PathBuf::from(home).join(".clawcrate"));
     }
     let cwd = std::env::current_dir()
         .map_err(|source| anyhow!("failed to resolve current dir: {source}"))?;
-    Ok(cwd.join(".clawcrate").join("runs"))
+    Ok(cwd.join(".clawcrate"))
+}
+
+fn configure_optional_sqlite_index(output: &OutputOptions) -> Option<SqliteAuditIndex> {
+    let explicit_path = std::env::var_os("CLAWCRATE_AUDIT_SQLITE_PATH").map(PathBuf::from);
+    let enabled_by_flag = std::env::var("CLAWCRATE_AUDIT_SQLITE")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    let db_path = match explicit_path {
+        Some(path) => path,
+        None if enabled_by_flag => match clawcrate_home_root() {
+            Ok(root) => root.join(DEFAULT_AUDIT_DB),
+            Err(error) => {
+                eprintln!("warning: failed to resolve default SQLite audit path: {error}");
+                return None;
+            }
+        },
+        None => return None,
+    };
+
+    match SqliteAuditIndex::open(&db_path) {
+        Ok(index) => {
+            verbose_log(
+                output,
+                1,
+                format!(
+                    "sqlite audit index enabled at {}",
+                    index.db_path().display()
+                ),
+            );
+            Some(index)
+        }
+        Err(error) => {
+            eprintln!("warning: failed to initialize SQLite audit index: {error}");
+            None
+        }
+    }
+}
+
+fn maybe_index_artifacts_in_sqlite(
+    index: &mut Option<SqliteAuditIndex>,
+    writer: &ArtifactWriter,
+    output: &OutputOptions,
+) {
+    let Some(indexer) = index.as_mut() else {
+        return;
+    };
+
+    match indexer.index_artifacts_dir(writer.artifacts_dir()) {
+        Ok(indexed) => {
+            verbose_log(
+                output,
+                2,
+                format!(
+                    "sqlite audit index updated: execution_id={}, events={}, has_result={}",
+                    indexed.execution_id, indexed.event_count, indexed.has_result
+                ),
+            );
+        }
+        Err(error) => {
+            eprintln!("warning: failed to index run artifacts in SQLite: {error}");
+        }
+    }
 }
 
 fn resolve_fs_diff_roots(plan: &ExecutionPlan) -> Vec<PathBuf> {

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -140,3 +140,21 @@ When a command appears to request permissions outside the active profile,
 - interactive mode: prompt (`Approve and continue? [y/N]`)
 - non-interactive / `--json`: fail-closed by default
 - automation override: `--approve-out-of-profile`
+
+## Optional SQLite Audit Index (P2)
+
+File artifacts remain the primary source of truth (`plan.json`, `result.json`, `audit.ndjson`).
+For query-oriented integrations, you can enable optional SQLite indexing:
+
+```bash
+CLAWCRATE_AUDIT_SQLITE=1 clawcrate run --profile build --json -- cargo test
+```
+
+Optional custom path:
+
+```bash
+CLAWCRATE_AUDIT_SQLITE_PATH=/tmp/clawcrate-audit.db clawcrate run --profile safe --json -- echo ok
+```
+
+When enabled, ClawCrate upserts run metadata and audit events into SQLite after each run,
+without changing artifact generation behavior.


### PR DESCRIPTION
## Summary
- add SQLite-backed indexing to clawcrate-audit for execution metadata and audit events
- keep file artifacts as source of truth and index from artifacts without changing existing artifact flow
- wire optional indexing into clawcrate run using CLAWCRATE_AUDIT_SQLITE or CLAWCRATE_AUDIT_SQLITE_PATH
- document optional SQLite index usage in integration guide

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #45