### PR TITLE
docs(p3-01): add wsl2 compatibility spike and constraints report

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ See [CHANGELOG.md](CHANGELOG.md) for release notes and version history.
 See [docs/release-checklist.md](docs/release-checklist.md) for the alpha release and tagging runbook.
 See [docs/egress-proxy-threat-model.md](docs/egress-proxy-threat-model.md) for the post-alpha network-filtering design baseline.
 See [docs/community-profiles.md](docs/community-profiles.md) for the community profile catalog schema and contribution workflow.
+See [docs/wsl2-compatibility.md](docs/wsl2-compatibility.md) for the current WSL2 compatibility constraints report.
 See [docs/architecture.md](docs/architecture.md), [docs/profiles-reference.md](docs/profiles-reference.md), [docs/kernel-requirements.md](docs/kernel-requirements.md), and [docs/integration-guide.md](docs/integration-guide.md) for the alpha technical docs pack.
 
 ## License

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -183,6 +183,7 @@ fi
 
 - Linux full kernel enforcement is tracked as ongoing work (issue `#69`).
 - macOS and Linux differ in backend internals; keep your integration backend-agnostic by consuming `result` + artifacts.
+- WSL2 is currently experimental/post-alpha; see [WSL2 compatibility spike](wsl2-compatibility.md).
 
 ## Post-Alpha Filtered Network Mode (P1)
 

--- a/docs/kernel-requirements.md
+++ b/docs/kernel-requirements.md
@@ -6,6 +6,7 @@ This page describes current platform assumptions for alpha behavior.
 
 - Linux
 - macOS
+- WSL2 (experimental, post-alpha guidance only)
 
 Other platforms currently return unsupported errors for `run`/`doctor`.
 
@@ -94,3 +95,17 @@ clawcrate doctor --json
 ```
 
 Use the JSON output in CI/automation to gate where specific profiles are allowed.
+
+## WSL2 (Post-Alpha Spike Status)
+
+WSL2 support is currently tracked as post-alpha roadmap scope.
+
+Current position:
+
+- treat WSL2 as experimental
+- validate capability signals via `doctor --json`
+- do not assume Landlock/seccomp parity with native Linux kernels
+
+Detailed constraints/workarounds report:
+
+- [WSL2 Compatibility Spike](wsl2-compatibility.md)

--- a/docs/wsl2-compatibility.md
+++ b/docs/wsl2-compatibility.md
@@ -1,0 +1,85 @@
+# WSL2 Compatibility Spike (P3-01)
+
+This note captures the current compatibility assessment for running ClawCrate under WSL2.
+
+Status: post-alpha exploratory guidance. WSL2 is not part of current alpha support guarantees.
+
+## Scope
+
+This spike focuses on:
+
+- Landlock/seccomp capability behavior in WSL2 Linux kernels.
+- Practical constraints and safe operating guidance.
+- Explicit unsupported or not-yet-validated areas.
+
+Related issues:
+
+- `#48` (this spike and constraints report)
+- `#49` (WSL2 CI lane + baseline validation)
+- `#69` (real Linux enforcement implementation gap)
+
+## Assessment Method
+
+Use `clawcrate doctor --json` inside WSL2 and gate behavior from reported capabilities:
+
+- `landlock_abi`
+- `seccomp_available`
+- `user_namespaces`
+- `kernel_version`
+
+Example:
+
+```bash
+clawcrate doctor --json | jq .
+```
+
+## Capability Expectations in WSL2
+
+WSL2 behavior varies by Windows version and WSL kernel build. Do not assume parity with native Linux.
+
+### Landlock
+
+- May be unavailable or partially available depending on kernel configuration.
+- If `landlock_abi` is `null`, treat path-level Linux restrictions as unavailable.
+
+### seccomp
+
+- Often available, but still kernel/config dependent.
+- If `seccomp_available` is `false`, syscall filtering guarantees are unavailable.
+
+### user namespaces
+
+- May be restricted by host policy.
+- Treat as informational for now; not a standalone security guarantee.
+
+## Current Risk Interpretation
+
+Even when capabilities appear available in WSL2, current repo state must be considered:
+
+- Linux enforcement internals are still tracked as active work in `#69`.
+- WSL2 has no dedicated CI lane yet (`#49`), so regressions are harder to detect.
+
+Result: WSL2 should be treated as experimental until both `#69` and `#49` are complete.
+
+## Recommended Operational Policy (Current)
+
+1. Run `clawcrate doctor --json` at startup and gate execution policy.
+2. If `landlock_abi == null` or `seccomp_available == false`, restrict usage to lower-risk flows:
+   - prefer `plan` over `run` for untrusted inputs
+   - prefer `safe`/`build` with minimal write scope
+   - use Replica mode for higher-risk operations
+3. For strict security boundaries, prefer native Linux or VM isolation until WSL2 baseline is CI-validated.
+
+## Known Unsupported / Not Yet Validated
+
+- No repository CI job currently validates WSL2 behavior.
+- No formal support claim for production WSL2 security posture at this stage.
+- Capability parity across Windows releases and custom WSL kernels is not guaranteed.
+
+## Next Step (P3-02)
+
+Issue `#49` should establish:
+
+- a repeatable WSL2 CI lane
+- minimum passing capability baseline
+- explicit pass/fail criteria for WSL2 support claims


### PR DESCRIPTION
## Summary
- add dedicated WSL2 compatibility spike report with capability expectations, constraints, workarounds, and unsupported areas
- document how to use clawcrate doctor --json for runtime gating inside WSL2
- link WSL2 guidance from kernel requirements, integration guide, and README

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #48