### PR TITLE
feat(m4): normalize profile filesystem paths in execution plan

### DIFF
--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -28,7 +28,7 @@ use clawcrate_sandbox::linux_probe::probe_linux_capabilities;
 use clawcrate_sandbox::macos_probe::probe_macos_capabilities;
 use clawcrate_types::{
     Actor, AuditEvent, AuditEventKind, DefaultMode, ExecutionPlan, ExecutionResult, NetLevel,
-    Platform, Status, SystemCapabilities, WorkspaceMode,
+    Platform, ResolvedProfile, Status, SystemCapabilities, WorkspaceMode,
 };
 use comfy_table::{Cell, Table};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
@@ -999,6 +999,19 @@ fn resolve_execution_path(cwd: &Path, path: &Path) -> PathBuf {
     }
 }
 
+fn normalize_profile_filesystem_paths(profile: &mut ResolvedProfile, execution_cwd: &Path) {
+    profile.fs_read = profile
+        .fs_read
+        .iter()
+        .map(|path| resolve_execution_path(execution_cwd, path))
+        .collect();
+    profile.fs_write = profile
+        .fs_write
+        .iter()
+        .map(|path| resolve_execution_path(execution_cwd, path))
+        .collect();
+}
+
 fn maybe_start_filtered_egress_proxy(
     net: &NetLevel,
     env: &mut Vec<(String, String)>,
@@ -1644,7 +1657,7 @@ fn build_execution_plan(
     cwd: &Path,
     args: &CommandArgs,
 ) -> Result<ExecutionPlan> {
-    let profile = match args.profile.as_deref() {
+    let mut profile = match args.profile.as_deref() {
         Some(explicit) => resolver.resolve(explicit),
         None => resolver.resolve_auto(cwd),
     }
@@ -1657,6 +1670,7 @@ fn build_execution_plan(
         WorkspaceMode::Direct => cwd.to_path_buf(),
         WorkspaceMode::Replica { copy, .. } => copy.clone(),
     };
+    normalize_profile_filesystem_paths(&mut profile, &execution_cwd);
 
     Ok(ExecutionPlan {
         id: execution_id,
@@ -2790,6 +2804,107 @@ mod tests {
             WorkspaceMode::Direct => {
                 panic!("--replica should override profile default direct mode")
             }
+        }
+    }
+
+    #[test]
+    fn build_execution_plan_normalizes_profile_paths_in_direct_mode() {
+        let resolver = ProfileResolver::default();
+        let cwd = unique_tmp_dir("clawcrate_cli_plan_normalized_direct");
+
+        let args = CommandArgs {
+            profile: Some("install".to_string()),
+            replica: false,
+            direct: true,
+            json: false,
+            approve_out_of_profile: false,
+            command: vec!["npm".to_string(), "install".to_string()],
+        };
+
+        let plan = build_execution_plan(&resolver, &cwd, &args).expect("build execution plan");
+        assert!(matches!(plan.mode, WorkspaceMode::Direct));
+        assert!(plan.profile.fs_read.iter().any(|path| path == &cwd));
+        assert!(plan
+            .profile
+            .fs_write
+            .iter()
+            .any(|path| path == &cwd.join("node_modules")));
+        assert!(plan
+            .profile
+            .fs_write
+            .iter()
+            .any(|path| path == &cwd.join(".venv")));
+        assert!(plan
+            .profile
+            .fs_write
+            .iter()
+            .any(|path| path == &cwd.join("target")));
+
+        if let Some(home) = std::env::var_os("HOME") {
+            let home = PathBuf::from(home);
+            assert!(plan
+                .profile
+                .fs_read
+                .iter()
+                .any(|path| path == &home.join(".npm")));
+            assert!(plan
+                .profile
+                .fs_write
+                .iter()
+                .any(|path| path == &home.join(".npm")));
+            assert!(plan
+                .profile
+                .fs_write
+                .iter()
+                .any(|path| path == &home.join(".cache/pip")));
+        }
+    }
+
+    #[test]
+    fn build_execution_plan_normalizes_profile_paths_in_replica_mode() {
+        let resolver = ProfileResolver::default();
+        let cwd = unique_tmp_dir("clawcrate_cli_plan_normalized_replica");
+
+        let args = CommandArgs {
+            profile: Some("install".to_string()),
+            replica: false,
+            direct: false,
+            json: false,
+            approve_out_of_profile: false,
+            command: vec!["npm".to_string(), "install".to_string()],
+        };
+
+        let plan = build_execution_plan(&resolver, &cwd, &args).expect("build execution plan");
+        let copy = match &plan.mode {
+            WorkspaceMode::Replica { copy, .. } => copy.clone(),
+            WorkspaceMode::Direct => panic!("install should default to replica"),
+        };
+
+        assert_eq!(plan.cwd, copy);
+        assert!(plan.profile.fs_read.iter().any(|path| path == &copy));
+        assert!(plan
+            .profile
+            .fs_write
+            .iter()
+            .any(|path| path == &copy.join("node_modules")));
+        assert!(plan
+            .profile
+            .fs_write
+            .iter()
+            .any(|path| path == &copy.join(".venv")));
+
+        if let Some(home) = std::env::var_os("HOME") {
+            let home = PathBuf::from(home);
+            assert!(plan
+                .profile
+                .fs_read
+                .iter()
+                .any(|path| path == &home.join(".cargo")));
+            assert!(plan
+                .profile
+                .fs_write
+                .iter()
+                .any(|path| path == &home.join(".cargo/registry")));
         }
     }
 

--- a/crates/clawcrate-cli/tests/golden_cli_outputs.rs
+++ b/crates/clawcrate-cli/tests/golden_cli_outputs.rs
@@ -53,10 +53,38 @@ fn run_clawcrate_text(args: &[&str], cwd: &Path, home: &Path) -> String {
 }
 
 fn normalize_plan_json(mut plan: Value) -> String {
+    let cwd = plan["cwd"].as_str().map(|value| value.to_string());
+    if let Some(cwd) = cwd.as_deref() {
+        relativize_plan_profile_paths_to_cwd(&mut plan, cwd);
+    }
     plan["id"] = json!("<EXECUTION_ID>");
     plan["cwd"] = json!("<EXECUTION_CWD>");
     plan["created_at"] = json!("<CREATED_AT>");
     serde_json::to_string_pretty(&plan).expect("serialize normalized plan")
+}
+
+fn relativize_plan_profile_paths_to_cwd(plan: &mut Value, cwd: &str) {
+    let Some(profile) = plan.get_mut("profile").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for field in ["fs_read", "fs_write"] {
+        let Some(paths) = profile.get_mut(field).and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for path in paths.iter_mut() {
+            let Some(value) = path.as_str() else {
+                continue;
+            };
+            if value == cwd || value == format!("{cwd}/.") {
+                *path = json!(".");
+                continue;
+            }
+            let prefix = format!("{cwd}/");
+            if let Some(rest) = value.strip_prefix(&prefix) {
+                *path = json!(format!("./{rest}"));
+            }
+        }
+    }
 }
 
 fn normalize_doctor_json(mut doctor: Value) -> String {


### PR DESCRIPTION
## Summary
- introduces canonical normalization for profile filesystem path vectors during `build_execution_plan`
- normalizes both `fs_read` and `fs_write` using execution context (`direct` vs `replica`) so backend prepare/run consume consistent paths
- keeps home-expansion and relative path resolution centralized in one place for plan/run/backend flow
- adds regression tests for normalization in direct and replica modes (including `~` and nested relative paths)
- updates plan JSON golden normalization to keep snapshots stable after absolute path materialization

## Validation
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #77
