### PR TITLE
fix(cli): fail closed for ambiguous filtered-network targets

### DIFF
--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -1158,6 +1158,10 @@ fn detect_out_of_profile_requests(plan: &ExecutionPlan) -> Vec<String> {
         NetLevel::Filtered { allowed_domains } => {
             let hosts = extract_hosts_from_command(&plan.command);
             if hosts.is_empty() {
+                requested.push(
+                    "command appears to need network, but filtered-mode host extraction was ambiguous; explicit approval required"
+                        .to_string(),
+                );
                 return requested;
             }
 
@@ -2746,6 +2750,29 @@ mod tests {
         let requests = detect_out_of_profile_requests(&denied_plan);
         assert_eq!(requests.len(), 1);
         assert!(requests[0].contains("evil.example.com"));
+    }
+
+    #[test]
+    fn approval_detection_flags_ambiguous_filtered_targets() {
+        let curl_without_scheme = mock_plan(
+            NetLevel::Filtered {
+                allowed_domains: vec!["example.com".to_string()],
+            },
+            &["curl", "example.com"],
+        );
+        let requests = detect_out_of_profile_requests(&curl_without_scheme);
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].contains("host extraction was ambiguous"));
+
+        let variable_target = mock_plan(
+            NetLevel::Filtered {
+                allowed_domains: vec!["example.com".to_string()],
+            },
+            &["curl", "$TARGET_URL"],
+        );
+        let requests = detect_out_of_profile_requests(&variable_target);
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].contains("host extraction was ambiguous"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make filtered-network approval detection fail closed when command looks networked but host extraction is ambiguous/empty
- keep the path auditable by producing an out-of-profile request that flows through existing ApprovalDecision events
- add regression tests for ambiguous targets including <!doctype html><html lang="en"><head><title>Example Domain</title><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href="https://iana.org/domains/example">Learn more</a></p></div></body></html> and variable-based targets

## Validation
- cargo fmt --all
- cargo test -p clawcrate-cli --bin clawcrate approval_detection
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Closes #102