### PR TITLE
chore(release): harden install/release script argument and checksum handling

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -45,6 +45,38 @@ bash scripts/release.sh package \
 bash scripts/release.sh checksums --dist-dir /tmp/clawcrate-dist-local
 ```
 
+Script hardening spot checks (`#109`):
+
+```bash
+# cut_release.sh rejects missing --tag value before shifting args
+if bash scripts/cut_release.sh --tag --skip-verify; then
+  echo "unexpected success"
+  exit 1
+fi
+
+# release.sh cleans temporary package dir on failure
+cargo build -p clawcrate-cli
+tmp_root="$(mktemp -d)"
+readonly_dist="$tmp_root/readonly-dist"
+mkdir -p "$readonly_dist"
+chmod 0555 "$readonly_dist"
+before_tmp_dirs="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'clawcrate-release.*' | sort)"
+if bash scripts/release.sh package \
+  --target x86_64-unknown-linux-musl \
+  --binary target/debug/clawcrate \
+  --dist-dir "$readonly_dist"; then
+  echo "unexpected success"
+  exit 1
+fi
+after_tmp_dirs="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'clawcrate-release.*' | sort)"
+if [ "$before_tmp_dirs" != "$after_tmp_dirs" ]; then
+  echo "unexpected leftover clawcrate-release temp directory"
+  exit 1
+fi
+chmod 0755 "$readonly_dist"
+rm -rf "$tmp_root"
+```
+
 ## 3. Update Changelog
 
 - Update `[Unreleased]` in [`CHANGELOG.md`](../CHANGELOG.md).

--- a/scripts/cut_release.sh
+++ b/scripts/cut_release.sh
@@ -20,6 +20,11 @@ SKIP_VERIFY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --tag)
+      if [[ $# -lt 2 || -z "${2:-}" || "$2" == --* ]]; then
+        echo "error: --tag requires a value" >&2
+        usage >&2
+        exit 1
+      fi
       TAG="${2:-}"
       shift 2
       ;;
@@ -74,6 +79,9 @@ if [[ -n "$(git status --porcelain)" ]]; then
   echo "error: working tree is not clean; commit/stash changes first" >&2
   exit 1
 fi
+
+echo "==> Fetching origin/main for synchronization check"
+git fetch origin main --prune >/dev/null
 
 local_main="$(git rev-parse main)"
 remote_main="$(git rev-parse origin/main)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -172,7 +172,18 @@ echo "    install dir: $INSTALL_DIR"
 fetch_to_file "$BASE_URL/$ASSET_NAME" "$ARCHIVE_PATH"
 fetch_to_file "$BASE_URL/SHA256SUMS" "$CHECKSUMS_PATH"
 
-expected_sum="$(grep "  $ASSET_NAME\$" "$CHECKSUMS_PATH" | awk '{print $1}' | head -n1)"
+expected_sum="$(
+  awk -v asset="$ASSET_NAME" '
+    NF >= 2 {
+      filename = $2
+      sub(/^[*]/, "", filename)
+      if (filename == asset) {
+        print $1
+        exit
+      }
+    }
+  ' "$CHECKSUMS_PATH"
+)"
 if [ -z "$expected_sum" ]; then
   echo "error: checksum entry not found for $ASSET_NAME" >&2
   exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -71,14 +71,18 @@ package_cmd() {
   fi
 
   mkdir -p "$dist_dir"
-  local tmp_dir
-  tmp_dir="$(mktemp -d)"
+  local archive_path="$dist_dir/clawcrate-${target}.tar.gz"
 
-  cp "$binary" "$tmp_dir/clawcrate"
-  chmod 0755 "$tmp_dir/clawcrate"
-  tar -C "$tmp_dir" -czf "$dist_dir/clawcrate-${target}.tar.gz" clawcrate
-  rm -rf "$tmp_dir"
-  echo "packaged: $dist_dir/clawcrate-${target}.tar.gz"
+  (
+    tmp_dir=""
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/clawcrate-release.XXXXXX")"
+    trap 'rm -rf "$tmp_dir"' EXIT
+
+    cp "$binary" "$tmp_dir/clawcrate"
+    chmod 0755 "$tmp_dir/clawcrate"
+    tar -C "$tmp_dir" -czf "$archive_path" clawcrate
+  )
+  echo "packaged: $archive_path"
 }
 
 checksums_cmd() {


### PR DESCRIPTION
## Summary
- harden scripts/install.sh checksum lookup by selecting the checksum using the filename column (including *filename format) instead of spacing-sensitive grep
- harden scripts/release.sh package temp-dir lifecycle with trap-guarded cleanup and a clawcrate-release.* mktemp prefix for clearer diagnostics
- harden scripts/cut_release.sh argument safety by validating --tag values before shifting args, and fetch origin/main before local vs remote sync comparison
- add manual script-hardening verification steps to docs/release-checklist.md

## Testing
- sh -n scripts/install.sh
- bash -n scripts/release.sh
- bash -n scripts/cut_release.sh
- bash scripts/cut_release.sh --tag --skip-verify (expected failure: --tag requires a value)
- cargo build -p clawcrate-cli
- manual failure-path packaging check using read-only dist dir: command fails and clawcrate-release.* temp-dir set remains unchanged before/after
- manual checksum parsing check with sample SHA256SUMS lines (space and *filename forms)

Closes #109