### PR TITLE
docs(repo): add technical triage note for PRs #82-#100

### DIFF
--- a/docs/technical-note-gemini-triage-pr82-pr100.md
+++ b/docs/technical-note-gemini-triage-pr82-pr100.md
@@ -1,0 +1,67 @@
+# Technical Note: Gemini Triage for PRs #82-#100
+
+Status (as of 2026-04-25): completed triage log for the review wave covering PRs
+`#82` to `#100`.
+
+## Purpose
+
+Track technical triage for Gemini Code Assist findings across merged PRs
+`#82`-`#100` and record disposition per finding.
+
+## Scope Reviewed
+
+PRs reviewed:
+
+- `#82`
+- `#83`
+- `#84`
+- `#85`
+- `#87`
+- `#88`
+- `#90`
+- `#91`
+- `#92`
+- `#93`
+- `#94`
+- `#95`
+- `#96`
+- `#97`
+- `#98`
+- `#99`
+- `#100`
+
+## Severity Summary
+
+- Security-high/high concentration: filtered proxy and approval/API surfaces.
+- Medium concentration: robustness, ergonomics, and documentation consistency.
+
+## Actionable Follow-ups and Disposition
+
+All follow-up issues created from this triage wave are now closed:
+
+| Issue | Topic | State | Closed At (UTC) |
+|---|---|---|---|
+| `#101` | Filtered egress proxy fail-closed + DoS boundaries | Closed | 2026-04-24T01:04:10Z |
+| `#102` | Filtered-network approval bypass for ambiguous targets | Closed | 2026-04-24T00:46:22Z |
+| `#103` | Host parsing for userinfo forms in approval allowlist checks | Closed | 2026-04-25T02:44:32Z |
+| `#104` | Local API server responsiveness and auth handling | Closed | 2026-04-25T02:57:09Z |
+| `#105` | Structured JSON errors for PennyPrompt bridge validation | Closed | 2026-04-25T03:06:55Z |
+| `#106` | Replica sync-back interaction safety and delete semantics | Closed | 2026-04-25T03:20:10Z |
+| `#107` | Community catalog path normalization before uniqueness checks | Closed | 2026-04-25T03:39:31Z |
+| `#108` | SQLite audit indexer path/large artifact robustness | Closed | 2026-04-25T03:55:31Z |
+| `#109` | Release/install script argument safety + checksum parsing | Closed | 2026-04-25T04:06:36Z |
+| `#110` | Egress proxy threat model docs hardening | Closed | 2026-04-25T04:22:14Z |
+| `#111` | WSL2 fail-safe guidance until Linux enforcement (`#69`) | Closed | 2026-04-25T14:22:46Z |
+
+## Deferred / Non-Blocking Items
+
+Deferred recommendations are tracked separately in issue `#113` to keep
+security-correctness and behavioral hardening work prioritized.
+
+## Completion Check
+
+Done criteria from issue `#112`:
+
+- Issues `#101`-`#111` triaged and resolved in the tracker: complete.
+- Deferred/non-critical recommendations split into dedicated note: complete via
+  `#113`.


### PR DESCRIPTION
## Summary
- add a dedicated technical note for Gemini triage across merged PRs #82-#100
- record reviewed scope, severity summary, and disposition ledger for follow-up issues #101-#111
- capture completion status against issue #112 done criteria
- link deferred/non-blocking recommendations to issue #113

## Testing
- docs-only change (manual content verification)

Closes #112
