### PR TITLE
docs(repo): add deferred Gemini recommendations note for PRs #82-#100

### DIFF
--- a/docs/technical-note-gemini-deferred-pr82-pr100.md
+++ b/docs/technical-note-gemini-deferred-pr82-pr100.md
@@ -1,0 +1,57 @@
+# Technical Note: Deferred Gemini Recommendations for PRs #82-#100
+
+Status (as of 2026-04-25): deferred/non-blocking recommendations documented.
+
+## Purpose
+
+Capture Gemini recommendations from PRs `#82`-`#100` that were intentionally
+deferred because they are non-critical for the current execution order.
+
+## Scope Source
+
+- Review wave tracked in `#112`.
+- Deferred bucket tracked in `#113` (this note).
+
+## Deferred Recommendations (Non-Blocking)
+
+1. Replica copy micro-optimizations and idiomatic cleanup.
+- Examples: `target_path` allocation timing, helper signature polish.
+
+2. Test utility refactors and cleanup.
+- Examples: `unique_tmp_dir` deduplication, selective `tempfile` migration,
+  golden-map ordering cleanup where behavior is unchanged.
+
+3. Documentation polish-only cleanups.
+- Examples: markdown heading hierarchy adjustments and structure-only edits that
+  do not change security/behavioral guidance.
+
+## Why Deferred
+
+- Security correctness and behavioral hardening were prioritized first in the
+  `#101`-`#111` execution set.
+- Deferred items do not currently introduce direct security bypasses in shipped
+  behavior.
+- Most items are maintainability/style improvements that are safer to batch in
+  dedicated cleanup PRs.
+
+## Re-entry Criteria
+
+Deferred items should be resumed when all of the following are true:
+
+1. No open critical-path hardening issue is blocked by the cleanup work.
+2. The change set can be isolated as behavior-preserving refactor/polish.
+3. CI is green before and after refactor with no output contract drift.
+
+## Recommended Handling
+
+- Batch runtime code cleanups in a dedicated refactor PR with explicit
+  "no-behavior-change" scope.
+- Batch docs polish in a separate docs-only PR to avoid mixing with runtime
+  security changes.
+- Keep references to this note from future backlog grooming/status updates.
+
+## Related
+
+- Primary triage note: `docs/technical-note-gemini-triage-pr82-pr100.md`
+- Tracking issues: `#112`, `#113`
+- Existing hardening context: `#69`, `#75`

--- a/docs/technical-note-gemini-triage-pr82-pr100.md
+++ b/docs/technical-note-gemini-triage-pr82-pr100.md
@@ -55,8 +55,13 @@ All follow-up issues created from this triage wave are now closed:
 
 ## Deferred / Non-Blocking Items
 
-Deferred recommendations are tracked separately in issue `#113` to keep
-security-correctness and behavioral hardening work prioritized.
+Deferred recommendations are tracked in:
+
+- issue `#113`
+- `docs/technical-note-gemini-deferred-pr82-pr100.md`
+
+This keeps security-correctness and behavioral hardening work prioritized while
+preserving a clear cleanup backlog.
 
 ## Completion Check
 
@@ -64,4 +69,4 @@ Done criteria from issue `#112`:
 
 - Issues `#101`-`#111` triaged and resolved in the tracker: complete.
 - Deferred/non-critical recommendations split into dedicated note: complete via
-  `#113`.
+  `#113` and `docs/technical-note-gemini-deferred-pr82-pr100.md`.


### PR DESCRIPTION
## Summary
- add a dedicated technical note documenting deferred/non-blocking Gemini recommendations from PRs #82-#100
- record deferred categories, rationale, re-entry criteria, and recommended batching strategy for future cleanup work
- update the main triage note to explicitly reference the new deferred note for complete traceability across #112 and #113

## Testing
- docs-only change (manual content verification)

Closes #113
