### PR TITLE
fix(sandbox): make Linux rlimit resource typing musl-compatible

### DIFF
--- a/crates/clawcrate-sandbox/src/linux.rs
+++ b/crates/clawcrate-sandbox/src/linux.rs
@@ -63,6 +63,10 @@ pub enum LinuxSandboxError {
 
 #[cfg(target_os = "linux")]
 const LINUX_RLIMIT_TARGET_COUNT: usize = 5;
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+type LinuxRlimitResource = libc::__rlimit_resource_t;
+#[cfg(all(target_os = "linux", not(target_env = "gnu")))]
+type LinuxRlimitResource = libc::c_int;
 #[cfg(target_os = "linux")]
 const LANDLOCK_RULE_PATH_BENEATH: u32 = 1;
 #[cfg(target_os = "linux")]
@@ -106,7 +110,7 @@ const LANDLOCK_ACCESS_FS_BASE_WRITE: u64 = LANDLOCK_ACCESS_FS_WRITE_FILE
 #[cfg(target_os = "linux")]
 #[derive(Clone, Copy, Debug)]
 struct LinuxRlimitTarget {
-    resource: libc::__rlimit_resource_t,
+    resource: LinuxRlimitResource,
     desired_soft: libc::rlim_t,
 }
 
@@ -144,23 +148,23 @@ fn build_linux_rlimit_targets(
 ) -> [LinuxRlimitTarget; LINUX_RLIMIT_TARGET_COUNT] {
     [
         LinuxRlimitTarget {
-            resource: libc::RLIMIT_CPU,
+            resource: libc::RLIMIT_CPU as LinuxRlimitResource,
             desired_soft: saturating_u64_to_rlim_t(limits.max_cpu_seconds),
         },
         LinuxRlimitTarget {
-            resource: libc::RLIMIT_AS,
+            resource: libc::RLIMIT_AS as LinuxRlimitResource,
             desired_soft: saturating_u64_to_rlim_t(memory_mb_to_bytes(limits.max_memory_mb)),
         },
         LinuxRlimitTarget {
-            resource: libc::RLIMIT_NOFILE,
+            resource: libc::RLIMIT_NOFILE as LinuxRlimitResource,
             desired_soft: saturating_u64_to_rlim_t(limits.max_open_files),
         },
         LinuxRlimitTarget {
-            resource: libc::RLIMIT_FSIZE,
+            resource: libc::RLIMIT_FSIZE as LinuxRlimitResource,
             desired_soft: saturating_u64_to_rlim_t(limits.max_output_bytes),
         },
         LinuxRlimitTarget {
-            resource: libc::RLIMIT_NPROC,
+            resource: libc::RLIMIT_NPROC as LinuxRlimitResource,
             desired_soft: saturating_u64_to_rlim_t(limits.max_processes),
         },
     ]


### PR DESCRIPTION
## Summary
- fix Linux rlimit resource typing to compile on both glibc and musl libc targets
- keep gnu builds using `libc::__rlimit_resource_t`
- use `libc::c_int` for non-gnu Linux targets (musl), matching libc signatures there

## Why
Release workflow for tag `v0.1.0-alpha.0` is failing on `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` with:
- `cannot find type __rlimit_resource_t in crate libc`

## Validation
- `cargo check -p clawcrate-sandbox --target x86_64-unknown-linux-musl`
- `cargo check -p clawcrate-sandbox --target aarch64-unknown-linux-musl`
- `cargo test -p clawcrate-sandbox egress_proxy::tests::proxy_preserves_pipelined_tls_preface_after_connect_headers -- --exact`

Refs #165