### PR TITLE
ci(release): move x86_64-apple release build to macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             use_cross: true
-          - os: macos-13
+          - os: macos-14
             target: x86_64-apple-darwin
             use_cross: false
           - os: macos-14


### PR DESCRIPTION
## Summary
- switch release matrix entry for `x86_64-apple-darwin` from `macos-13` to `macos-14`
- keep existing target list unchanged; only runner image changes

## Why
Release runs for tag `v0.1.0-alpha.0` are stalling with `x86_64-apple-darwin` queued indefinitely on `macos-13`, blocking publish step and GitHub release asset publication.

## Validation
- workflow yaml syntax unchanged (single matrix OS label update)
- prior release run evidence: all other targets completed successfully; only `x86_64-apple-darwin` remained queued

Refs #165