### PR TITLE
docs: sweep stale #69 references and align roadmap status

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,10 +297,13 @@ Run `clawcrate doctor` to check your system's capabilities.
 ## Roadmap
 
 - [x] Project specification (v3.1.1)
-- [ ] **Alpha** — `run`, `plan`, `doctor`, `api`, `bridge pennyprompt`. Profiles. Dual-platform sandbox. Replica mode. Artifacts.
-- [ ] **P1** — Egress proxy (network filtering by domain). Approval workflow. Community profiles.
-- [ ] **P2** — SQLite audit storage. API/bridge hardening and expanded integration contracts.
+- [x] **Alpha** — `run`, `plan`, `doctor`, `api`, `bridge pennyprompt`. Profiles. Dual-platform sandbox. Replica mode. Artifacts.
+- [x] **P1** — Egress proxy (network filtering by domain). Approval workflow. Community profiles.
+- [x] **P2** — SQLite audit storage. API/bridge hardening and expanded integration contracts.
 - [ ] **v1.0** — Production hardening. Windows (WSL2). Plugin system.
+
+Transition note:
+Alpha release `v0.1.0-alpha.0` is published. P1/P2 capabilities are present in `main`; remaining open issues are hardening and consistency follow-ups.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,8 @@ Current backend path:
 
 Important current state:
 
-- Enforcement steps are wired but currently no-op in `KernelEnforcer`.
-- Tracked as technical gap in issue `#69` ("Implement real Linux enforcement").
+- Linux enforcement is active in runtime (`rlimits`, `landlock`, `seccomp`) and applied in launch pre-exec flow.
+- Historical note: issue `#69` ("Implement real Linux enforcement") is closed.
 
 ## macOS backend
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -181,7 +181,7 @@ fi
 
 ## Current Alpha Caveats
 
-- Linux full kernel enforcement is tracked as ongoing work (issue `#69`).
+- Linux full kernel enforcement is implemented in current `main`.
 - macOS and Linux differ in backend internals; keep your integration backend-agnostic by consuming `result` + artifacts.
 - WSL2 is currently experimental/post-alpha; see [WSL2 compatibility spike](wsl2-compatibility.md).
 

--- a/docs/kernel-requirements.md
+++ b/docs/kernel-requirements.md
@@ -33,10 +33,8 @@ In the current alpha codebase, Linux launch stages are wired as:
 - `landlock`
 - `seccomp`
 
-But the default `KernelEnforcer` implementation is currently no-op for those steps.
-Tracked in issue `#69` ("Implement real Linux enforcement").
-
-That means Linux capability detection is present, but full enforcement remains an active gap.
+These stages are implemented and enforced during Linux launch.
+Historical note: issue `#69` ("Implement real Linux enforcement") is closed.
 
 ## macOS
 
@@ -71,7 +69,7 @@ These limits map profile resources to:
 - file size
 - process count (platform conditional)
 
-Integration into platform launch behavior is in progress and should be interpreted alongside issue `#69`.
+Integration into platform launch behavior is implemented in current `main`.
 
 ## Replica Mode and Secret Handling
 

--- a/docs/wsl2-compatibility.md
+++ b/docs/wsl2-compatibility.md
@@ -4,7 +4,8 @@ This note captures the current compatibility assessment for running ClawCrate un
 
 Status (as of 2026-04-25): post-alpha exploratory guidance.
 WSL2 is not part of current alpha support guarantees.
-Fail-safe posture remains in effect until Linux enforcement work in `#69` is complete.
+Fail-safe posture remains in effect while WSL2 support is still experimental.
+Historical note: Linux enforcement issue `#69` is closed.
 
 ## Scope
 
@@ -18,7 +19,6 @@ Related issues:
 
 - `#48` (this spike and constraints report)
 - `#49` (WSL2 CI lane + baseline validation)
-- `#69` (real Linux enforcement implementation gap)
 
 ## Assessment Method
 
@@ -36,7 +36,7 @@ clawcrate doctor --json | jq .
 ```
 
 Important: these fields are compatibility signals only. They are not a security
-readiness verdict while `#69` is open.
+readiness verdict.
 
 ## Capability Expectations in WSL2
 
@@ -61,25 +61,25 @@ WSL2 behavior varies by Windows version and WSL kernel build. Do not assume pari
 
 Even when capabilities appear available in WSL2, current repo state must be considered:
 
-- Linux enforcement internals are still tracked as active work in `#69`.
+- Linux enforcement internals are implemented on native Linux.
 - WSL2 now has a dedicated CI execution path (`.github/workflows/wsl2-ci.yml`), currently configured as non-blocking while support is still experimental.
 
 Result:
 
-- Until `#69` lands, treat WSL2 as restricted/experimental regardless of
-  `landlock_abi` or `seccomp_available` values.
+- Treat WSL2 as restricted/experimental regardless of `landlock_abi` or
+  `seccomp_available` values.
 - Non-null capability probes do not override this restriction.
 - CI results from `wsl2-ci` are for drift/signal collection, not a security guarantee.
 
 ## Recommended Operational Policy (Current)
 
-1. Apply a default restricted policy for all WSL2 runs while `#69` remains open.
+1. Apply a default restricted policy for all WSL2 runs while support remains experimental.
 2. Run `clawcrate doctor --json` for observability and troubleshooting, not as a pass/fail trust gate.
 3. If `landlock_abi == null` or `seccomp_available == false`, further restrict usage to lower-risk flows:
    - prefer `plan` over `run` for untrusted inputs
    - prefer `safe`/`build` with minimal write scope
    - use Replica mode for higher-risk operations
-4. For strict security boundaries, prefer native Linux or VM isolation until Linux enforcement (`#69`) is implemented and validated.
+4. For strict security boundaries, prefer native Linux or VM isolation until WSL2 support is promoted beyond experimental status.
 
 ## Known Unsupported / Not Yet Validated
 
@@ -103,4 +103,4 @@ This lane is intentionally non-blocking right now (`continue-on-error: true`) to
 Interpretation rule:
 
 - Passing `WSL2 Compatibility` indicates runtime compatibility signal only.
-- It does not certify sandbox enforcement guarantees on WSL2 prior to `#69`.
+- It does not certify production-grade sandbox enforcement guarantees on WSL2.


### PR DESCRIPTION
## Summary
- remove stale documentation claims that Linux enforcement is still pending under issue #69
- keep a short historical note that #69 is closed where useful for context
- update integration/kernel/architecture docs to reflect current runtime enforcement status
- align README roadmap status with published alpha release and delivered P1/P2 capabilities
- update WSL2 note to remain experimental for WSL2-specific reasons instead of tying it to #69

## Validation
- grep sweep confirms no active claims that #69 is open/pending in affected docs

Closes #167