### PR TITLE
chore(release): harden cut_release preflight checks

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -92,8 +92,11 @@ bash scripts/cut_release.sh --tag v0.1.0-alpha.0 --push
 
 What it enforces:
 - clean working tree
+- explicit dirty-entry output when tree is not clean
 - `main` branch only
 - local `main` equals `origin/main`
+- remote tag collision check (fails if tag already exists on `origin`)
+- required release artifact paths exist (`scripts/release.sh`, `scripts/install.sh`, `.github/workflows/release.yml`)
 - local quality gate (`fmt`, `clippy`, `test`)
 - annotated tag creation
 - optional remote push

--- a/scripts/cut_release.sh
+++ b/scripts/cut_release.sh
@@ -77,8 +77,17 @@ fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "error: working tree is not clean; commit/stash changes first" >&2
+  echo "hint: current dirty entries:" >&2
+  git status --short >&2
   exit 1
 fi
+
+for required_path in scripts/release.sh scripts/install.sh .github/workflows/release.yml; do
+  if [[ ! -f "$required_path" ]]; then
+    echo "error: required release artifact path is missing: $required_path" >&2
+    exit 1
+  fi
+done
 
 echo "==> Fetching origin/main for synchronization check"
 git fetch origin main --prune >/dev/null
@@ -93,6 +102,11 @@ fi
 
 if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
   echo "error: tag '$TAG' already exists locally" >&2
+  exit 1
+fi
+
+if [[ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]]; then
+  echo "error: tag '$TAG' already exists on origin" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- fail fast with explicit dirty-entry output when working tree is not clean
- enforce required release artifact paths before tag creation (`scripts/release.sh`, `scripts/install.sh`, `.github/workflows/release.yml`)
- fail if the target tag already exists on origin (remote collision guard)
- document the new enforced preflight behavior in release checklist

## Why
Release cut previously relied on implicit/manual guardrails for some conditions (artifact path assumptions and remote tag collision).

Closes #169