### PR TITLE
docs(triage): align PR #82-#100 scope and deferred links

### DIFF
--- a/docs/technical-note-gemini-deferred-pr82-pr100.md
+++ b/docs/technical-note-gemini-deferred-pr82-pr100.md
@@ -9,21 +9,22 @@ deferred because they are non-critical for the current execution order.
 
 ## Scope Source
 
-- Review wave tracked in `#112`.
-- Deferred bucket tracked in `#113` (this note).
+- Review wave tracked in
+  [Issue #112](https://github.com/manuelpenazuniga/ClawCrate/issues/112).
+- Deferred bucket tracked in
+  [Issue #113](https://github.com/manuelpenazuniga/ClawCrate/issues/113)
+  (this note).
 
 ## Deferred Recommendations (Non-Blocking)
 
-1. Replica copy micro-optimizations and idiomatic cleanup.
-- Examples: `target_path` allocation timing, helper signature polish.
-
-2. Test utility refactors and cleanup.
-- Examples: `unique_tmp_dir` deduplication, selective `tempfile` migration,
-  golden-map ordering cleanup where behavior is unchanged.
-
-3. Documentation polish-only cleanups.
-- Examples: markdown heading hierarchy adjustments and structure-only edits that
-  do not change security/behavioral guidance.
+1. Replica copy micro-optimizations and idiomatic cleanup (for example:
+   `target_path` allocation timing, helper signature polish).
+2. Test utility refactors and cleanup (for example: `unique_tmp_dir`
+   deduplication, selective `tempfile` migration, golden-map ordering cleanup
+   where behavior is unchanged).
+3. Documentation polish-only cleanups (for example: markdown heading hierarchy
+   adjustments and structure-only edits that do not change security/behavioral
+   guidance).
 
 ## Why Deferred
 
@@ -52,6 +53,11 @@ Deferred items should be resumed when all of the following are true:
 
 ## Related
 
-- Primary triage note: `docs/technical-note-gemini-triage-pr82-pr100.md`
-- Tracking issues: `#112`, `#113`
-- Existing hardening context: `#69`, `#75`
+- Primary triage note:
+  [docs/technical-note-gemini-triage-pr82-pr100.md](technical-note-gemini-triage-pr82-pr100.md)
+- Tracking issues:
+  [#112](https://github.com/manuelpenazuniga/ClawCrate/issues/112),
+  [#113](https://github.com/manuelpenazuniga/ClawCrate/issues/113)
+- Existing hardening context:
+  [#69](https://github.com/manuelpenazuniga/ClawCrate/issues/69),
+  [#75](https://github.com/manuelpenazuniga/ClawCrate/issues/75)

--- a/docs/technical-note-gemini-triage-pr82-pr100.md
+++ b/docs/technical-note-gemini-triage-pr82-pr100.md
@@ -10,14 +10,18 @@ Track technical triage for Gemini Code Assist findings across merged PRs
 
 ## Scope Reviewed
 
+Review wave scope: PRs `#82`-`#100` (inclusive), 19 PRs total.
+
 PRs reviewed:
 
 - `#82`
 - `#83`
 - `#84`
 - `#85`
+- `#86`
 - `#87`
 - `#88`
+- `#89`
 - `#90`
 - `#91`
 - `#92`
@@ -57,8 +61,8 @@ All follow-up issues created from this triage wave are now closed:
 
 Deferred recommendations are tracked in:
 
-- issue `#113`
-- `docs/technical-note-gemini-deferred-pr82-pr100.md`
+- [Issue #113](https://github.com/manuelpenazuniga/ClawCrate/issues/113)
+- [Deferred Gemini Recommendations for PRs #82-#100](technical-note-gemini-deferred-pr82-pr100.md)
 
 This keeps security-correctness and behavioral hardening work prioritized while
 preserving a clear cleanup backlog.
@@ -69,4 +73,5 @@ Done criteria from issue `#112`:
 
 - Issues `#101`-`#111` triaged and resolved in the tracker: complete.
 - Deferred/non-critical recommendations split into dedicated note: complete via
-  `#113` and `docs/technical-note-gemini-deferred-pr82-pr100.md`.
+  [#113](https://github.com/manuelpenazuniga/ClawCrate/issues/113) and
+  [docs/technical-note-gemini-deferred-pr82-pr100.md](technical-note-gemini-deferred-pr82-pr100.md).


### PR DESCRIPTION
## Summary
- reconcile triage scope in PR #82-#100 note by adding missing references to #86 and #89
- add explicit inclusive range statement for auditability (`#82`-`#100`, 19 PRs)
- fix markdown structure in deferred recommendations to render consistently
- convert triage/deferred cross-references to proper relative markdown links and issue links
- keep changes docs-only

## Validation
- cargo fmt --all -- --check

Closes #159
