### PR TITLE
docs(epic): close status remediation and alpha release epic #171

### DIFF
--- a/docs/epic-status-remediation-completion.md
+++ b/docs/epic-status-remediation-completion.md
@@ -1,0 +1,50 @@
+# Epic Completion: Status 2026-04-25 Remediation + Alpha Release Closure
+
+Status (as of 2026-04-30): ready to close epic `#171`.
+
+## Objective
+
+Close all remediation items derived from `docs/status-2026-04-25.md` with
+release readiness, runtime hardening, and docs consistency fully reconciled.
+
+## Done Criteria Check
+
+1. Critical path issues are closed (`#150`, `#153`, `#165`, `#166`).
+- `#150` closed via PR `#174`.
+- `#153` closed via PR `#175`.
+- `#166` closed via PR `#176`.
+- `#165` release publication closed via PRs `#177` and `#178`.
+
+2. Hardening wave follow-ups are closed (`#151`, `#152`, `#154`-`#159`).
+- `#151` closed via PR `#183`.
+- `#152` closed via PR `#184`.
+- `#154` closed via PR `#185`.
+- `#155` closed via PR `#186`.
+- `#156` closed via PR `#187`.
+- `#157` closed via PR `#188`.
+- `#158` closed via PR `#189`.
+- `#159` closed via PR `#190`.
+
+3. Documentation and release-ops alignment is closed (`#167`-`#170`).
+- `#167` closed via PR `#179`.
+- `#168` closed via PR `#180`.
+- `#169` closed via PR `#181`.
+- `#170` closed via PR `#182`.
+
+4. Release/tag is available and docs/public contract are aligned.
+- `v0.1.0-alpha.0` release pipeline and installer smoke lanes were completed in
+  the `#165`/`#170` track.
+- Alpha surface contract and technical notes were reconciled by `#166`,
+  `#167`, `#168`, and `#159`.
+
+## Traceability
+
+- Epic tracker: `#171`
+- Planning artifact: `#172` and
+  `docs/technical-note-status-remediation-plan-2026-04-26.md`
+- Final issue in the wave: `#159` (merged in PR `#190` on 2026-04-30)
+
+## Notes
+
+- This document is a closure artifact for epic `#171` and is intentionally
+  limited to completion evidence.


### PR DESCRIPTION
## Summary
- add `docs/epic-status-remediation-completion.md` as closure artifact for epic `#171`
- map each critical-path, hardening, and docs/release-ops issue to merged PRs for auditable traceability
- confirm done-criteria evidence from the `status-2026-04-25` remediation wave and alpha release closure track
- keep changes docs-only

## Validation
- `cargo fmt --all -- --check`

Closes #171
