### PR TITLE
docs(triage): add Gemini findings disposition matrix for PRs #163-#190

### DIFF
--- a/docs/technical-note-gemini-disposition-pr163-pr190.md
+++ b/docs/technical-note-gemini-disposition-pr163-pr190.md
@@ -1,0 +1,67 @@
+# Technical Note: Gemini Findings Disposition for PRs #163-#190
+
+Status (as of 2026-04-30): actionable findings triaged into remediations,
+deferred items, and no-action items with rationale.
+
+## Purpose
+
+Record the disposition of Gemini Code Assist recommendations across merged PRs
+`#163`, `#164`, `#173`, `#175`, `#176`, `#183`, `#186`, `#188`, `#189`, and
+`#190`, and link each actionable item to a tracked issue.
+
+## Scope Reviewed
+
+- `#163` fix: prevent process-group broadcast signaling in interruption path
+- `#164` fix: close filtered-network ambiguity bypass on mixed targets
+- `#173` docs: add status-remediation execution plan
+- `#175` fix: harden seccomp pre-exec error path for async-signal-safety
+- `#176` docs: reconcile alpha scope with exposed CLI surface
+- `#183` fix(sandbox): apply hard rlimit caps with soft limits
+- `#186` fix(cli): return structured bridge JSON on stdin read failures
+- `#188` test(sandbox): harden linux security fixture lifecycle and deps
+- `#189` fix(sandbox): normalize backend path expansion semantics end-to-end
+- `#190` docs(triage): align PR #82-#100 scope and deferred links
+
+## Disposition Matrix
+
+| PR | Gemini recommendation summary | Disposition | Tracking |
+|---|---|---|---|
+| `#163` | Make interruption signal delivery more robust when targeting PID/PGID paths | Follow-up required | `#192` |
+| `#164` | Simplify duplicated error message/readability in out-of-profile detection | Deferred (non-blocking) | `#197` |
+| `#173` | Adjust heading/time phrasing and ordering for editorial consistency | No action | n/a |
+| `#175` | Harden seccomp pre-exec failure path against potential allocator interaction on drop | Follow-up required | `#193` |
+| `#176` | Fill command synopsis gaps and changelog consistency | Already addressed in merged docs | n/a |
+| `#183` | Improve test assertion style (numeric parsing vs. string comparison) | Deferred (non-blocking) | `#197` |
+| `#186` | Prefer more idiomatic stdin read helper style | Deferred (non-blocking) | `#197` |
+| `#188` | Make temporary fixture cleanup symlink-safe | Follow-up required | `#194` |
+| `#189` | Reduce duplicated path-normalization logic and strengthen path parsing robustness | Follow-up required | `#195` |
+| `#190` | Clarify deferred-note parenthetical wording | Deferred (docs polish) | `#197` |
+
+## Rationale
+
+### Follow-up required
+
+- `#192` and `#193` are runtime-hardening items and are prioritized as P1 in
+  the tracker.
+- `#194` and `#195` improve fixture safety and reduce maintenance drift risk in
+  sandbox backend path logic.
+
+### Deferred / non-blocking
+
+- Recommendations for `#164`, `#183`, `#186`, and `#190` are valid quality
+  improvements but do not currently create a security bypass or release blocker.
+- These remain tracked under `#197` and can be batched in cleanup PRs.
+
+### No action
+
+- `#173` is a date-scoped planning artifact; its temporal framing is
+  intentional and auditable for historical reconstruction.
+
+## Tracking
+
+- Program tracker: `#197`
+- Actionable follow-ups:
+  - `#192`
+  - `#193`
+  - `#194`
+  - `#195`


### PR DESCRIPTION
## Summary
- add `docs/technical-note-gemini-disposition-pr163-pr190.md`
- document per-PR disposition for Gemini recommendations across PRs `#163` to `#190`
- classify findings as follow-up required, deferred, or no-action with explicit rationale
- map actionable findings to tracked issues: `#192`, `#193`, `#194`, `#195`
- link residual deferred work to tracker `#197`

## Validation
- `cargo fmt --all -- --check`

Closes #196
