### PR TITLE
fix(sandbox): harden seccomp pre-exec error drop path

### DIFF
--- a/crates/clawcrate-sandbox/src/linux.rs
+++ b/crates/clawcrate-sandbox/src/linux.rs
@@ -761,13 +761,16 @@ fn apply_linux_seccomp_filter(context: &LinuxSeccompContext) -> io::Result<()> {
 fn seccomp_apply_error_as_io_error(source: SeccompApplyError) -> io::Error {
     // Keep pre_exec failure conversion allocator-free: emit deterministic raw errno values instead
     // of formatted strings so the child post-fork path remains async-signal-safe.
-    let errno = match source {
+    let errno = match &source {
         SeccompApplyError::Prctl(error) => error.raw_os_error().unwrap_or(libc::EINVAL),
         SeccompApplyError::Seccomp(error) => error.raw_os_error().unwrap_or(libc::EINVAL),
         SeccompApplyError::ThreadSync(_) => libc::EBUSY,
         SeccompApplyError::EmptyFilter => libc::EINVAL,
         SeccompApplyError::Backend(_) => libc::EINVAL,
     };
+    // Intentionally leak this value post-fork to avoid running Drop glue in the child pre-exec
+    // failure path, where touching allocator state is not async-signal-safe.
+    std::mem::forget(source);
     io::Error::from_raw_os_error(errno)
 }
 
@@ -1172,6 +1175,11 @@ mod tests {
 
         let empty_filter_error = seccomp_apply_error_as_io_error(seccompiler::Error::EmptyFilter);
         assert_eq!(empty_filter_error.raw_os_error(), Some(nix::libc::EINVAL));
+
+        let backend_error = seccomp_apply_error_as_io_error(seccompiler::Error::Backend(
+            seccompiler::BackendError::InvalidArgumentNumber,
+        ));
+        assert_eq!(backend_error.raw_os_error(), Some(nix::libc::EINVAL));
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- harden Linux seccomp pre-exec error conversion to avoid dropping `seccompiler::Error` values in the child post-fork path
- derive errno mapping from a borrowed view of the error and intentionally `mem::forget` the owned error value to avoid Drop glue in pre-exec failure handling
- extend seccomp mapping tests to cover backend error variant mapping to deterministic `EINVAL`

## Validation
- `cargo fmt --all`
- `cargo clippy -p clawcrate-sandbox --all-targets -- -D warnings`
- `cargo test -p clawcrate-sandbox`

Closes #193
