### PR TITLE
refactor(sandbox): share path normalization across linux and darwin

### DIFF
--- a/crates/clawcrate-sandbox/src/darwin.rs
+++ b/crates/clawcrate-sandbox/src/darwin.rs
@@ -9,6 +9,7 @@ use clawcrate_types::{ExecutionPlan, NetLevel};
 use thiserror::Error;
 
 use crate::env_scrub::scrub_environment;
+use crate::path_normalize::{home_from_env_pairs, normalize_path_patterns, normalize_paths};
 
 #[derive(Debug, Clone)]
 pub struct DarwinSandboxPaths {
@@ -83,15 +84,15 @@ impl DarwinSandbox {
             &plan.profile.env_scrub,
             &plan.profile.env_passthrough,
         );
-        let home = home_from_env(&scrubbed.kept);
+        let home = home_from_env_pairs(&scrubbed.kept);
 
         let mut prepared = PreparedDarwinSandbox {
             execution_id: plan.id.clone(),
             command: plan.command.clone(),
             cwd: plan.cwd.clone(),
-            fs_read: normalize_prepared_paths(&plan.cwd, &plan.profile.fs_read, home.as_deref()),
-            fs_write: normalize_prepared_paths(&plan.cwd, &plan.profile.fs_write, home.as_deref()),
-            fs_deny: normalize_deny_patterns(&plan.cwd, &plan.profile.fs_deny, home.as_deref()),
+            fs_read: normalize_paths(&plan.cwd, &plan.profile.fs_read, home.as_deref()),
+            fs_write: normalize_paths(&plan.cwd, &plan.profile.fs_write, home.as_deref()),
+            fs_deny: normalize_path_patterns(&plan.cwd, &plan.profile.fs_deny, home.as_deref()),
             net: plan.profile.net.clone(),
             scrubbed_env: scrubbed.kept,
             scrubbed_keys: scrubbed.removed,
@@ -236,58 +237,6 @@ fn sanitize_identifier_component(value: &str, max_len: usize, fallback: &str) ->
     } else {
         sanitized
     }
-}
-
-fn home_from_env(env: &[(String, String)]) -> Option<PathBuf> {
-    env.iter()
-        .find_map(|(key, value)| (key == "HOME" && !value.is_empty()).then(|| PathBuf::from(value)))
-}
-
-fn expand_home_path(path: &Path, home: Option<&Path>) -> PathBuf {
-    let path_str = path.to_string_lossy();
-    if path_str == "~" {
-        if let Some(home_path) = home {
-            return home_path.to_path_buf();
-        }
-    }
-    if let Some(rest) = path_str.strip_prefix("~/") {
-        if let Some(home_path) = home {
-            return home_path.join(rest);
-        }
-    }
-    path.to_path_buf()
-}
-
-fn resolve_prepared_path(cwd: &Path, path: &Path, home: Option<&Path>) -> PathBuf {
-    let expanded = expand_home_path(path, home);
-    if expanded.is_absolute() {
-        expanded
-    } else {
-        cwd.join(expanded)
-    }
-}
-
-fn normalize_prepared_paths(cwd: &Path, paths: &[PathBuf], home: Option<&Path>) -> Vec<PathBuf> {
-    paths
-        .iter()
-        .map(|path| resolve_prepared_path(cwd, path, home))
-        .collect()
-}
-
-fn normalize_deny_pattern(cwd: &Path, pattern: &str, home: Option<&Path>) -> String {
-    let expanded = expand_home_path(Path::new(pattern), home);
-    if expanded.is_absolute() {
-        expanded.to_string_lossy().to_string()
-    } else {
-        cwd.join(expanded).to_string_lossy().to_string()
-    }
-}
-
-fn normalize_deny_patterns(cwd: &Path, patterns: &[String], home: Option<&Path>) -> Vec<String> {
-    patterns
-        .iter()
-        .map(|pattern| normalize_deny_pattern(cwd, pattern, home))
-        .collect()
 }
 
 fn generate_sbpl_profile(prepared: &PreparedDarwinSandbox, home: Option<&Path>) -> String {

--- a/crates/clawcrate-sandbox/src/lib.rs
+++ b/crates/clawcrate-sandbox/src/lib.rs
@@ -11,4 +11,5 @@ pub mod linux;
 pub mod linux_probe;
 #[cfg(target_os = "macos")]
 pub mod macos_probe;
+pub(crate) mod path_normalize;
 pub mod rlimits;

--- a/crates/clawcrate-sandbox/src/linux.rs
+++ b/crates/clawcrate-sandbox/src/linux.rs
@@ -1,11 +1,12 @@
 use std::io;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 
 use crate::env_scrub::{scrub_current_environment, scrub_environment};
+use crate::path_normalize::{home_from_env_pairs, normalize_paths};
 use clawcrate_types::{ExecutionPlan, NetLevel, ResourceLimits};
 #[cfg(target_os = "linux")]
 use nix::{errno::Errno, libc};
@@ -36,42 +37,6 @@ pub struct PreparedLinuxSandbox {
     pub resource_limits: ResourceLimits,
     pub scrubbed_env: Vec<(String, String)>,
     pub scrubbed_keys: Vec<String>,
-}
-
-fn home_from_env_pairs(env: &[(String, String)]) -> Option<PathBuf> {
-    env.iter()
-        .find_map(|(key, value)| (key == "HOME" && !value.is_empty()).then(|| PathBuf::from(value)))
-}
-
-fn expand_home_path(path: &Path, home: Option<&Path>) -> PathBuf {
-    let path_str = path.to_string_lossy();
-    if path_str == "~" {
-        if let Some(home_path) = home {
-            return home_path.to_path_buf();
-        }
-    }
-    if let Some(rest) = path_str.strip_prefix("~/") {
-        if let Some(home_path) = home {
-            return home_path.join(rest);
-        }
-    }
-    path.to_path_buf()
-}
-
-fn resolve_prepared_path(cwd: &Path, path: &Path, home: Option<&Path>) -> PathBuf {
-    let expanded = expand_home_path(path, home);
-    if expanded.is_absolute() {
-        expanded
-    } else {
-        cwd.join(expanded)
-    }
-}
-
-fn normalize_prepared_paths(cwd: &Path, paths: &[PathBuf], home: Option<&Path>) -> Vec<PathBuf> {
-    paths
-        .iter()
-        .map(|path| resolve_prepared_path(cwd, path, home))
-        .collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -492,8 +457,8 @@ impl LinuxSandbox {
             execution_id: plan.id.clone(),
             command: plan.command.clone(),
             cwd: plan.cwd.clone(),
-            fs_read: normalize_prepared_paths(&plan.cwd, &plan.profile.fs_read, home.as_deref()),
-            fs_write: normalize_prepared_paths(&plan.cwd, &plan.profile.fs_write, home.as_deref()),
+            fs_read: normalize_paths(&plan.cwd, &plan.profile.fs_read, home.as_deref()),
+            fs_write: normalize_paths(&plan.cwd, &plan.profile.fs_write, home.as_deref()),
             net: plan.profile.net.clone(),
             resource_limits: plan.profile.resources.clone(),
             scrubbed_env: scrubbed.kept,

--- a/crates/clawcrate-sandbox/src/linux.rs
+++ b/crates/clawcrate-sandbox/src/linux.rs
@@ -1,6 +1,8 @@
 use std::io;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(target_os = "linux")]
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;

--- a/crates/clawcrate-sandbox/src/path_normalize.rs
+++ b/crates/clawcrate-sandbox/src/path_normalize.rs
@@ -40,6 +40,7 @@ pub(crate) fn normalize_paths(cwd: &Path, paths: &[PathBuf], home: Option<&Path>
         .collect()
 }
 
+#[cfg(target_os = "macos")]
 pub(crate) fn normalize_path_patterns(
     cwd: &Path,
     patterns: &[String],

--- a/crates/clawcrate-sandbox/src/path_normalize.rs
+++ b/crates/clawcrate-sandbox/src/path_normalize.rs
@@ -1,0 +1,53 @@
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) fn home_from_env_pairs(env: &[(String, String)]) -> Option<PathBuf> {
+    env.iter()
+        .find_map(|(key, value)| (key == "HOME" && !value.is_empty()).then(|| PathBuf::from(value)))
+}
+
+pub(crate) fn expand_home_path(path: &Path, home: Option<&Path>) -> PathBuf {
+    let mut components = path.components();
+    match components.next() {
+        Some(Component::Normal(component)) if component == OsStr::new("~") => {
+            if let Some(home_path) = home {
+                let mut expanded = home_path.to_path_buf();
+                for part in components {
+                    expanded.push(part.as_os_str());
+                }
+                return expanded;
+            }
+        }
+        _ => {}
+    }
+
+    path.to_path_buf()
+}
+
+pub(crate) fn resolve_path_with_home(cwd: &Path, path: &Path, home: Option<&Path>) -> PathBuf {
+    let expanded = expand_home_path(path, home);
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        cwd.join(expanded)
+    }
+}
+
+pub(crate) fn normalize_paths(cwd: &Path, paths: &[PathBuf], home: Option<&Path>) -> Vec<PathBuf> {
+    paths
+        .iter()
+        .map(|path| resolve_path_with_home(cwd, path, home))
+        .collect()
+}
+
+pub(crate) fn normalize_path_patterns(
+    cwd: &Path,
+    patterns: &[String],
+    home: Option<&Path>,
+) -> Vec<String> {
+    patterns
+        .iter()
+        .map(|pattern| resolve_path_with_home(cwd, Path::new(pattern), home))
+        .map(|resolved| resolved.to_string_lossy().to_string())
+        .collect()
+}


### PR DESCRIPTION
## Summary
- extract duplicated backend path normalization into shared sandbox module: `crates/clawcrate-sandbox/src/path_normalize.rs`
- centralize `HOME` extraction, `~` expansion, cwd-relative resolution, and batch path normalization logic
- keep Linux and Darwin backend behavior unchanged while removing duplicated helper implementations
- retain Darwin deny-pattern normalization semantics through shared pattern normalization helper

## Validation
- `cargo fmt --all`
- `cargo clippy -p clawcrate-sandbox --all-targets -- -D warnings`
- `cargo test -p clawcrate-sandbox`

Closes #195
