### PR TITLE
docs(readme): install script from latest release asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ npm test runs normally. Your secrets never left the vault.
 
 ```bash
 # Install (macOS)
-curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/ClawCrate/main/scripts/install.sh | sh
+curl -fsSL https://github.com/manuelpenazuniga/ClawCrate/releases/latest/download/install.sh | sh
 
 # Install (Linux)
-curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/ClawCrate/main/scripts/install.sh | sh
+curl -fsSL https://github.com/manuelpenazuniga/ClawCrate/releases/latest/download/install.sh | sh
 
 # Run your first sandboxed command
 clawcrate run --profile safe -- echo "hello from the sandbox"


### PR DESCRIPTION
## Summary
- switch Quickstart install command from mutable raw main-branch URL
- use stable release asset endpoint for both macOS and Linux snippets

## Why
Using the release asset decouples install instructions from main branch head drift and keeps installs aligned with published artifacts.

## Validation
- verified README install snippets now point to release asset URL
- confirmed no raw.githubusercontent.com scripts/install.sh reference remains in README

Closes #203
