### PR TITLE
fix(sandbox): restore macOS run stability under seatbelt

### DIFF
--- a/crates/clawcrate-sandbox/src/darwin.rs
+++ b/crates/clawcrate-sandbox/src/darwin.rs
@@ -243,6 +243,7 @@ fn generate_sbpl_profile(prepared: &PreparedDarwinSandbox, home: Option<&Path>) 
     let mut lines = vec![
         "(version 1)".to_string(),
         "(deny default)".to_string(),
+        "(import \"system.sb\")".to_string(),
         "(allow process-exec)".to_string(),
         "(allow process-fork)".to_string(),
         "(allow signal (target self))".to_string(),
@@ -434,6 +435,7 @@ mod tests {
 
         assert!(prepared.sbpl_profile.contains("(version 1)"));
         assert!(prepared.sbpl_profile.contains("(deny default)"));
+        assert!(prepared.sbpl_profile.contains("(import \"system.sb\")"));
         assert!(prepared.sbpl_profile.contains("(allow file-read-metadata)"));
         assert!(prepared.sbpl_profile.contains("(allow sysctl-read)"));
         assert!(prepared.sbpl_profile.contains("(deny network*)"));
@@ -612,6 +614,46 @@ exec \"$@\"\n",
 
         let result = sandbox.launch(&prepared);
         assert!(matches!(result, Err(DarwinSandboxError::EmptyCommand)));
+    }
+
+    #[test]
+    fn launch_with_real_sandbox_exec_runs_trivial_command() {
+        if !Path::new("/usr/bin/sandbox-exec").is_file() {
+            return;
+        }
+
+        let sandbox = DarwinSandbox::new();
+        let tmp = unique_tmp_dir("clawcrate_darwin_real_sandbox_exec");
+        let workspace = tmp.join("workspace");
+        fs::create_dir_all(&workspace).expect("create workspace for real sandbox test");
+
+        let mut plan = test_plan(
+            vec!["/bin/echo".to_string(), "smoke".to_string()],
+            NetLevel::None,
+        );
+        plan.cwd = workspace.clone();
+        plan.profile.fs_read = vec![workspace];
+        plan.profile.fs_write = Vec::new();
+        plan.profile.fs_deny = Vec::new();
+
+        let prepared = sandbox.prepare_with_env(
+            &plan,
+            vec![
+                ("HOME".to_string(), "/tmp/home-runner".to_string()),
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+            ],
+        );
+
+        let child = sandbox
+            .launch(&prepared)
+            .expect("launch should succeed with real sandbox-exec");
+        let output = child.wait_with_output().expect("wait with output");
+        assert!(
+            output.status.success(),
+            "real sandbox-exec trivial command should succeed"
+        );
+        let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+        assert_eq!(stdout, "smoke\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- import system.sb into generated Seatbelt profiles to provide required macOS runtime baseline rules
- keep deny-by-default + explicit ClawCrate network/filesystem policy rules layered on top
- add real sandbox-exec regression test for trivial command execution

## Root Cause
Generated SBPL denied required baseline runtime operations for dynamically linked binaries, causing child processes to terminate as Killed/signal exits.

## Validation
- cargo test -p clawcrate-sandbox darwin::tests::launch_with_real_sandbox_exec_runs_trivial_command
- cargo test -p clawcrate-sandbox
- cargo clippy --workspace --all-targets -- -D warnings
- cargo run -p clawcrate-cli -- run --profile safe -- echo smoke (now status=success)

Closes #205
