### PR TITLE
docs(release): prep metadata for v0.1.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ with alpha pre-release tags.
 
 ## [Unreleased]
 
+## [0.1.0-alpha.1] - 2026-04-30
+
 ### Added
 - Release automation workflow for multi-target binary artifacts and checksum publication.
 - Install script with platform/architecture detection and SHA256 verification.
 
 ### Changed
 - Reconciled alpha scope contract: documented command surface now explicitly includes `api` and `bridge pennyprompt` alongside `run`, `plan`, and `doctor`.
+
+### Fixed
+- Built-in profile names (`safe`, `build`, `install`, `open`) now resolve correctly in installed release binaries without requiring a local repository checkout.
+- macOS Seatbelt SBPL generation now imports the system baseline profile to prevent trivial sandboxed commands from terminating as `Killed`.
 
 ## [0.1.0-alpha.0] - 2026-04-18
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Run `clawcrate doctor` to check your system's capabilities.
 - [ ] **v1.0** — Production hardening. Windows (WSL2). Plugin system.
 
 Transition note:
-Alpha release `v0.1.0-alpha.0` is published. P1/P2 capabilities are present in `main`; remaining open issues are hardening and consistency follow-ups.
+The latest alpha release is published on GitHub Releases. Quickstart installs from the latest published release assets; see `CHANGELOG.md` for version-specific details.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- move current release-ready notes from Unreleased into 0.1.0-alpha.1 dated 2026-04-30
- document two critical fixes included in alpha.1 (#206, #205)
- make README transition note version-agnostic to avoid stale release text

## Why
Quickstart installs from release assets, so changelog/release notes must reflect the actual next tag content.

## Validation
- docs-only diff reviewed
- no code-path changes

Closes #209
