### PR TITLE
fix(release): align reported CLI version with alpha.1 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clawcrate-audit"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "chrono",
  "clawcrate-types",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "clawcrate-capture"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "clawcrate-types",
  "serde",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "clawcrate-cli"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "clawcrate-profiles"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "clawcrate-types",
  "serde",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "clawcrate-sandbox"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "chrono",
  "clawcrate-profiles",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "clawcrate-types"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default-members = ["crates/clawcrate-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.78"


### PR DESCRIPTION
## Summary
- bump workspace package version from 0.1.0-alpha.0 to 0.1.0-alpha.1
- refresh Cargo.lock package version entries accordingly

## Why
Release v0.1.0-alpha.1 assets were publishing binaries that still reported 0.1.0-alpha.0 on --version.

## Validation
- cargo run -p clawcrate-cli -- --version (reports 0.1.0-alpha.1)
- cargo test -p clawcrate-cli --test golden_cli_outputs
- cargo clippy -p clawcrate-cli --all-targets -- -D warnings

Closes #211
