### PR TITLE
chore(changelog): document 0.1.0-alpha.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ with alpha pre-release tags.
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2] - 2026-04-30
+
+### Fixed
+- Process-group signal fallback for deterministic SIGINT handling under nested child trees.
+- seccomp pre-exec errors now propagate correctly instead of being silently swallowed.
+- Symlink-safe temp fixture cleanup in sandbox integration tests.
+- Darwin-only path pattern normalization gated correctly so cross-platform clippy stays clean.
+
+### Changed
+- Centralized backend path normalization helpers (refactor, no behaviour change).
+- Workspace crate versions aligned to `0.1.0-alpha.2` before tag cut.
+
 ## [0.1.0-alpha.1] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The latest alpha release is published on GitHub Releases. Quickstart installs fr
 ClawCrate is MIT licensed. Contributions welcome.
 
 ```bash
-git clone https://github.com/anthropic-ai/clawcrate.git
+git clone https://github.com/manuelpenazuniga/ClawCrate.git
 cd clawcrate
 cargo build --workspace
 cargo test --workspace


### PR DESCRIPTION
## Summary

Adds the missing `[0.1.0-alpha.2]` section to `CHANGELOG.md`. The latest published tag is `v0.1.0-alpha.2` but the changelog only had an `alpha.1` entry, leaving new visitors with a contradictory trust signal.

Documents the bug-fix wave included in the alpha.2 tag:

- Process-group signal fallback for deterministic SIGINT handling
- seccomp pre-exec error propagation fix
- Symlink-safe temp fixture cleanup in sandbox tests
- Darwin-only path normalization gating for cross-platform clippy

## Test plan

- [x] `CHANGELOG.md` has a `[0.1.0-alpha.2] - 2026-04-30` section
- [x] `[Unreleased]` block is empty/reset
- [x] Dates and content match what was shipped in `v0.1.0-alpha.2`
- [x] No source code changes — `cargo test --workspace` unaffected

Closes #224