### PR TITLE
feat(profiles/community): add agent-inference-allowlist.yaml

### DIFF
--- a/profiles/community/agent-inference-allowlist.yaml
+++ b/profiles/community/agent-inference-allowlist.yaml
@@ -1,0 +1,37 @@
+name: agent-inference-allowlist
+extends: build
+description: >
+  Network allowlist for AI agents that call inference APIs.
+  Blocks all egress except the major AI provider endpoints.
+  Use this when your agent needs to call an LLM API but should
+  be blocked from reaching any other host.
+
+filesystem:
+  read:
+    - "."
+  write:
+    - "."
+
+network:
+  mode: filtered
+  allowed_domains:
+    - api.anthropic.com
+    - api.openai.com
+    - generativelanguage.googleapis.com
+    - api.cohere.com
+    - api.mistral.ai
+    - openrouter.ai
+
+environment:
+  scrub:
+    - "ANTHROPIC_API_KEY"
+    - "OPENAI_API_KEY"
+    - "COHERE_API_KEY"
+    - "MISTRAL_API_KEY"
+    - "*_SECRET*"
+    - "*_TOKEN*"
+  passthrough:
+    - HOME
+    - PATH
+    - LANG
+    - TMPDIR

--- a/profiles/community/agent-inference-allowlist.yaml
+++ b/profiles/community/agent-inference-allowlist.yaml
@@ -1,10 +1,5 @@
 name: agent-inference-allowlist
 extends: build
-description: >
-  Network allowlist for AI agents that call inference APIs.
-  Blocks all egress except the major AI provider endpoints.
-  Use this when your agent needs to call an LLM API but should
-  be blocked from reaching any other host.
 
 filesystem:
   read:

--- a/profiles/community/catalog.yaml
+++ b/profiles/community/catalog.yaml
@@ -16,3 +16,13 @@ profiles:
       - python
       - install
       - filtered-network
+  - id: agent-inference-allowlist
+    title: AI agent inference API allowlist (Anthropic, OpenAI, Gemini, Cohere, Mistral, OpenRouter)
+    path: agent-inference-allowlist.yaml
+    owner: "@clawcrate-community"
+    tags:
+      - agent
+      - inference
+      - filtered-network
+      - anthropic
+      - openai


### PR DESCRIPTION
## Summary

Adds `profiles/community/agent-inference-allowlist.yaml` — a community profile for AI agents that need to call inference APIs but should be blocked from reaching any other host.

Allowed domains:
- `api.anthropic.com`
- `api.openai.com`
- `generativelanguage.googleapis.com` (Gemini)
- `api.cohere.com`
- `api.mistral.ai`
- `openrouter.ai`

All other egress is blocked (`network: filtered`). API keys are scrubbed from the environment before the sandboxed process starts.

Also registers the profile in `profiles/community/catalog.yaml`.

## Test plan

- [ ] `clawcrate run --profile profiles/community/agent-inference-allowlist.yaml -- curl https://api.anthropic.com` → allowed
- [ ] `clawcrate run --profile profiles/community/agent-inference-allowlist.yaml -- curl https://evil.example.com` → blocked
- [ ] `ANTHROPIC_API_KEY` absent from sandboxed env (check `audit.ndjson` EnvScrubbed event)
- [ ] `catalog.yaml` entry present and valid

Closes #226