### PR TITLE
feat(audit): add Ed25519 audit block signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,8 +229,10 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "clawcrate-audit"
 version = "0.1.0-alpha.2"
 dependencies = [
+ "base64",
  "chrono",
  "clawcrate-types",
+ "ed25519-dalek",
  "rusqlite",
  "serde",
  "serde_json",
@@ -309,6 +323,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +402,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +456,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -429,6 +511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +536,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -714,6 +813,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +918,15 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -942,16 +1078,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1044,7 +1205,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1070,6 +1231,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1374,6 +1541,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/crates/clawcrate-audit/Cargo.toml
+++ b/crates/clawcrate-audit/Cargo.toml
@@ -10,8 +10,10 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clawcrate-types = { path = "../clawcrate-types" }
+ed25519-dalek = { version = "2", features = ["pem", "pkcs8"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = "1"
 serde_json = "1"

--- a/crates/clawcrate-audit/src/lib.rs
+++ b/crates/clawcrate-audit/src/lib.rs
@@ -4,9 +4,13 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use clawcrate_types::{AuditEvent, ExecutionPlan, ExecutionResult};
+use ed25519_dalek::pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePublicKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use rusqlite::{params, Connection};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 pub const CRATE_NAME: &str = "clawcrate-audit";
@@ -19,6 +23,7 @@ pub const RESULT_JSON: &str = "result.json";
 pub const AUDIT_NDJSON: &str = "audit.ndjson";
 pub const FS_DIFF_JSON: &str = "fs-diff.json";
 pub const DEFAULT_AUDIT_DB: &str = "audit-index.sqlite3";
+pub const DEFAULT_SIGNATURE_BLOCK_SIZE: usize = 100;
 
 /// Serialized ndjson line written when `CLAWCRATE_AUDIT_HASHCHAIN=1`.
 /// Flattens `AuditEvent` fields (`timestamp`, `event`) then appends the two
@@ -32,8 +37,32 @@ struct ChainedLine<'a> {
     current_hash: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlockSignature {
+    pub kind: String,
+    pub block_start: usize,
+    pub block_end: usize,
+    pub block_hash: String,
+    pub signature: String,
+    pub public_key_fingerprint: String,
+}
+
 fn hash_chain_enabled() -> bool {
     std::env::var("CLAWCRATE_AUDIT_HASHCHAIN").as_deref() == Ok("1")
+}
+
+fn audit_signing_key_path() -> Option<PathBuf> {
+    std::env::var_os("CLAWCRATE_AUDIT_SIGN")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn audit_signature_block_size() -> usize {
+    std::env::var("CLAWCRATE_AUDIT_SIGN_BLOCK_SIZE")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_SIGNATURE_BLOCK_SIZE)
 }
 
 /// Returns the `current_hash` from the last chained line in `path`, or
@@ -54,6 +83,66 @@ fn read_previous_hash(path: &Path) -> String {
                 .map(str::to_string)
         })
         .unwrap_or_else(|| GENESIS_HASH.to_string())
+}
+
+#[derive(Debug, Clone)]
+struct ChainEventLine {
+    current_hash: String,
+}
+
+#[derive(Debug, Clone)]
+struct AuditSignatureState {
+    events: Vec<ChainEventLine>,
+    signatures: Vec<BlockSignature>,
+}
+
+fn read_signature_state(path: &Path) -> Result<AuditSignatureState, ArtifactWriterError> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return Ok(AuditSignatureState {
+            events: Vec::new(),
+            signatures: Vec::new(),
+        });
+    };
+
+    let mut events = Vec::new();
+    let mut signatures = Vec::new();
+    for (index, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line).map_err(|source| {
+            ArtifactWriterError::ReadSignatureState {
+                path: path.to_path_buf(),
+                line: index + 1,
+                source,
+            }
+        })?;
+        if is_block_signature_value(&value) {
+            let signature: BlockSignature = serde_json::from_value(value).map_err(|source| {
+                ArtifactWriterError::ReadSignatureState {
+                    path: path.to_path_buf(),
+                    line: index + 1,
+                    source,
+                }
+            })?;
+            signatures.push(signature);
+            continue;
+        }
+
+        let parsed: ChainedLineRead = serde_json::from_value(value).map_err(|source| {
+            ArtifactWriterError::ReadSignatureState {
+                path: path.to_path_buf(),
+                line: index + 1,
+                source,
+            }
+        })?;
+        if let Some(current_hash) = parsed.current_hash {
+            events.push(ChainEventLine { current_hash });
+        }
+    }
+
+    Ok(AuditSignatureState { events, signatures })
 }
 
 /// Serializes `event` to RFC 8785 (JSON Canonicalization Scheme) canonical form.
@@ -84,6 +173,118 @@ pub fn compute_event_hash(event: &AuditEvent, previous_hash: &str) -> String {
     format!("sha256:{hex}")
 }
 
+pub fn compute_block_hash(event_hashes: &[String]) -> String {
+    let mut hasher = Sha256::new();
+    for event_hash in event_hashes {
+        hasher.update(event_hash.as_bytes());
+    }
+    let bytes = hasher.finalize();
+    format!("sha256:{}", hex_encode(&bytes))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn is_block_signature_value(value: &serde_json::Value) -> bool {
+    value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|kind| kind == "BlockSignature")
+}
+
+fn public_key_fingerprint(verifying_key: &VerifyingKey) -> Result<String, ArtifactWriterError> {
+    let der =
+        verifying_key
+            .to_public_key_der()
+            .map_err(|source| ArtifactWriterError::SigningKey {
+                path: PathBuf::from("<derived-public-key>"),
+                detail: source.to_string(),
+            })?;
+    let digest = Sha256::digest(der.as_bytes());
+    Ok(format!("SHA256:{}", BASE64_STANDARD.encode(digest)))
+}
+
+fn load_signing_key(path: &Path) -> Result<SigningKey, ArtifactWriterError> {
+    let pem = fs::read_to_string(path).map_err(|source| ArtifactWriterError::ReadSigningKey {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    SigningKey::from_pkcs8_pem(&pem).map_err(|source| ArtifactWriterError::SigningKey {
+        path: path.to_path_buf(),
+        detail: source.to_string(),
+    })
+}
+
+fn load_verifying_key(path: &Path) -> Result<VerifyingKey, VerifyChainError> {
+    let pem = fs::read_to_string(path).map_err(|source| VerifyChainError::ReadPublicKey {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    VerifyingKey::from_public_key_pem(&pem).map_err(|source| VerifyChainError::PublicKey {
+        path: path.to_path_buf(),
+        detail: source.to_string(),
+    })
+}
+
+fn maybe_build_signature(
+    path: &Path,
+    event: &AuditEvent,
+    block_size: usize,
+) -> Result<Option<BlockSignature>, ArtifactWriterError> {
+    let Some(key_path) = audit_signing_key_path() else {
+        return Ok(None);
+    };
+
+    let state = read_signature_state(path)?;
+    if state.events.is_empty() {
+        return Ok(None);
+    }
+
+    let next_start = state
+        .signatures
+        .iter()
+        .map(|signature| signature.block_end + 1)
+        .max()
+        .unwrap_or(0);
+    if next_start >= state.events.len() {
+        return Ok(None);
+    }
+
+    let pending_len = state.events.len() - next_start;
+    let should_close_block = pending_len >= block_size || is_terminal_event(event);
+    if !should_close_block {
+        return Ok(None);
+    }
+
+    let block_end = state.events.len() - 1;
+    let block_hash = compute_block_hash(
+        &state.events[next_start..=block_end]
+            .iter()
+            .map(|event| event.current_hash.clone())
+            .collect::<Vec<_>>(),
+    );
+    let signing_key = load_signing_key(&key_path)?;
+    let verifying_key = signing_key.verifying_key();
+    let signature = signing_key.sign(block_hash.as_bytes());
+    Ok(Some(BlockSignature {
+        kind: "BlockSignature".to_string(),
+        block_start: next_start,
+        block_end,
+        block_hash,
+        signature: format!("ed25519:{}", BASE64_STANDARD.encode(signature.to_bytes())),
+        public_key_fingerprint: public_key_fingerprint(&verifying_key)?,
+    }))
+}
+
+fn is_terminal_event(event: &AuditEvent) -> bool {
+    matches!(
+        event.event,
+        clawcrate_types::AuditEventKind::ProcessExited { .. }
+            | clawcrate_types::AuditEventKind::PermissionBlocked { .. }
+    )
+}
+
 // ── Hash-chain verification ───────────────────────────────────────────────────
 
 /// Line shape we deserialize when verifying a chained `audit.ndjson`.
@@ -101,6 +302,7 @@ struct ChainedLineRead {
 pub struct ChainVerifyResult {
     pub valid: bool,
     pub events_checked: usize,
+    pub signatures_checked: usize,
     /// 1-based index of the first tampered event, `None` when valid.
     pub tampered_at: Option<usize>,
     pub first_event_ts: Option<String>,
@@ -118,6 +320,10 @@ pub enum VerifyChainError {
     NoHashChain,
     #[error("I/O error reading audit.ndjson: {0}")]
     Io(#[from] io::Error),
+    #[error("failed to read Ed25519 public key at {path}: {source}")]
+    ReadPublicKey { path: PathBuf, source: io::Error },
+    #[error("failed to parse Ed25519 public key at {path}: {detail}")]
+    PublicKey { path: PathBuf, detail: String },
 }
 
 /// Reads `audit_path` and verifies the SHA-256 hash chain.
@@ -125,20 +331,30 @@ pub enum VerifyChainError {
 /// Returns `Ok(ChainVerifyResult)` for both valid and tampered chains;
 /// errors only for structural problems (file missing, no chain fields).
 pub fn verify_audit_chain(audit_path: &Path) -> Result<ChainVerifyResult, VerifyChainError> {
+    verify_audit_chain_with_pubkey(audit_path, None)
+}
+
+pub fn verify_audit_chain_with_pubkey(
+    audit_path: &Path,
+    pubkey_path: Option<&Path>,
+) -> Result<ChainVerifyResult, VerifyChainError> {
     if !audit_path.exists() {
         return Err(VerifyChainError::NotFound {
             path: audit_path.to_owned(),
         });
     }
 
+    let verifying_key = pubkey_path.map(load_verifying_key).transpose()?;
     let file = fs::File::open(audit_path).map_err(VerifyChainError::Io)?;
     let reader = BufReader::new(file);
 
     let mut events_checked: usize = 0;
+    let mut signatures_checked: usize = 0;
     let mut previous_hash = GENESIS_HASH.to_string();
     let mut first_ts: Option<String> = None;
     let mut last_ts: Option<String> = None;
     let mut has_chain_fields = false;
+    let mut event_hashes: Vec<String> = Vec::new();
 
     for (idx, line_result) in reader.lines().enumerate() {
         let line = line_result.map_err(VerifyChainError::Io)?;
@@ -147,7 +363,68 @@ pub fn verify_audit_chain(audit_path: &Path) -> Result<ChainVerifyResult, Verify
             continue;
         }
 
-        let parsed: ChainedLineRead = serde_json::from_str(line).map_err(|e| {
+        let value: serde_json::Value = serde_json::from_str(line).map_err(|e| {
+            VerifyChainError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("line {}: {e}", idx + 1),
+            ))
+        })?;
+        if is_block_signature_value(&value) {
+            let signature: BlockSignature = serde_json::from_value(value).map_err(|e| {
+                VerifyChainError::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("line {}: {e}", idx + 1),
+                ))
+            })?;
+            if let Some(verifying_key) = &verifying_key {
+                signatures_checked += 1;
+                if signature.block_start > signature.block_end
+                    || signature.block_end >= event_hashes.len()
+                {
+                    return Ok(ChainVerifyResult {
+                        valid: false,
+                        events_checked,
+                        signatures_checked,
+                        tampered_at: None,
+                        first_event_ts: first_ts,
+                        last_event_ts: last_ts,
+                        error: Some(format!(
+                            "invalid signature block range {}..={} at line {}",
+                            signature.block_start,
+                            signature.block_end,
+                            idx + 1
+                        )),
+                    });
+                }
+                let expected_block_hash =
+                    compute_block_hash(&event_hashes[signature.block_start..=signature.block_end]);
+                if expected_block_hash != signature.block_hash {
+                    return Ok(ChainVerifyResult {
+                        valid: false,
+                        events_checked,
+                        signatures_checked,
+                        tampered_at: None,
+                        first_event_ts: first_ts,
+                        last_event_ts: last_ts,
+                        error: Some(format!(
+                            "signature block hash mismatch at line {}: expected {}, found {}",
+                            idx + 1,
+                            expected_block_hash,
+                            signature.block_hash
+                        )),
+                    });
+                }
+                verify_block_signature(verifying_key, &signature).map_err(|e| {
+                    VerifyChainError::Io(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("line {}: {e}", idx + 1),
+                    ))
+                })?;
+            }
+            continue;
+        }
+
+        let parsed: ChainedLineRead = serde_json::from_value(value).map_err(|e| {
             VerifyChainError::Io(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("line {}: {e}", idx + 1),
@@ -172,12 +449,26 @@ pub fn verify_audit_chain(audit_path: &Path) -> Result<ChainVerifyResult, Verify
             None => continue, // unchained line — skip hash check
         };
         let stored_previous = parsed.previous_hash.as_deref().unwrap_or(GENESIS_HASH);
+        if stored_previous != previous_hash {
+            return Ok(ChainVerifyResult {
+                valid: false,
+                events_checked,
+                signatures_checked,
+                tampered_at: Some(event_no),
+                first_event_ts: first_ts,
+                last_event_ts: last_ts,
+                error: Some(format!(
+                    "previous_hash mismatch at event {event_no}: expected {previous_hash}, found {stored_previous}"
+                )),
+            });
+        }
 
         let expected = compute_event_hash(&parsed.event, stored_previous);
         if expected != stored_current {
             return Ok(ChainVerifyResult {
                 valid: false,
                 events_checked,
+                signatures_checked,
                 tampered_at: Some(event_no),
                 first_event_ts: first_ts,
                 last_event_ts: last_ts,
@@ -186,7 +477,8 @@ pub fn verify_audit_chain(audit_path: &Path) -> Result<ChainVerifyResult, Verify
                 )),
             });
         }
-        previous_hash = stored_current;
+        previous_hash = stored_current.clone();
+        event_hashes.push(stored_current);
     }
     let _ = previous_hash; // consumed for chain walk
 
@@ -197,11 +489,32 @@ pub fn verify_audit_chain(audit_path: &Path) -> Result<ChainVerifyResult, Verify
     Ok(ChainVerifyResult {
         valid: true,
         events_checked,
+        signatures_checked,
         tampered_at: None,
         first_event_ts: first_ts,
         last_event_ts: last_ts,
         error: None,
     })
+}
+
+fn verify_block_signature(
+    verifying_key: &VerifyingKey,
+    block_signature: &BlockSignature,
+) -> Result<(), String> {
+    let signature_bytes = block_signature
+        .signature
+        .strip_prefix("ed25519:")
+        .ok_or_else(|| "signature is missing ed25519: prefix".to_string())
+        .and_then(|encoded| {
+            BASE64_STANDARD
+                .decode(encoded)
+                .map_err(|source| format!("signature base64 decode failed: {source}"))
+        })?;
+    let signature = Signature::from_slice(&signature_bytes)
+        .map_err(|source| format!("signature parse failed: {source}"))?;
+    verifying_key
+        .verify(block_signature.block_hash.as_bytes(), &signature)
+        .map_err(|source| format!("signature verification failed: {source}"))
 }
 
 // ── ArtifactWriter ───────────────────────────────────────────────────────────
@@ -273,7 +586,7 @@ impl ArtifactWriter {
                 source,
             })?;
 
-        if hash_chain_enabled() {
+        if hash_chain_enabled() || audit_signing_key_path().is_some() {
             let previous_hash = read_previous_hash(&path);
             let current_hash = compute_event_hash(event, &previous_hash);
             let line = ChainedLine {
@@ -287,6 +600,29 @@ impl ArtifactWriter {
                     source,
                 }
             })?;
+            file.write_all(b"\n")
+                .map_err(|source| ArtifactWriterError::WriteIo {
+                    path: path.clone(),
+                    source,
+                })?;
+            file.flush()
+                .map_err(|source| ArtifactWriterError::WriteIo {
+                    path: path.clone(),
+                    source,
+                })?;
+
+            if let Some(signature) =
+                maybe_build_signature(&path, event, audit_signature_block_size())?
+            {
+                serde_json::to_writer(&mut file, &signature).map_err(|source| {
+                    ArtifactWriterError::WriteJson {
+                        path: path.clone(),
+                        source,
+                    }
+                })?;
+            } else {
+                return Ok(());
+            }
         } else {
             serde_json::to_writer(&mut file, event).map_err(|source| {
                 ArtifactWriterError::WriteJson {
@@ -332,6 +668,21 @@ pub enum ArtifactWriterError {
         path: PathBuf,
         #[source]
         source: io::Error,
+    },
+    #[error("failed to read Ed25519 signing key at {path}: {source}")]
+    ReadSigningKey {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to use Ed25519 signing key at {path}: {detail}")]
+    SigningKey { path: PathBuf, detail: String },
+    #[error("failed to read signature state at {path}, line {line}: {source}")]
+    ReadSignatureState {
+        path: PathBuf,
+        line: usize,
+        #[source]
+        source: serde_json::Error,
     },
 }
 
@@ -682,7 +1033,17 @@ fn read_ndjson_audit_events(path: &Path) -> Result<Vec<AuditEvent>, SqliteAuditI
         if line.trim().is_empty() {
             continue;
         }
-        let event = serde_json::from_str::<AuditEvent>(&line).map_err(|source| {
+        let value = serde_json::from_str::<serde_json::Value>(&line).map_err(|source| {
+            SqliteAuditIndexError::ParseNdjsonLine {
+                path: path.to_path_buf(),
+                line: index + 1,
+                source,
+            }
+        })?;
+        if is_block_signature_value(&value) {
+            continue;
+        }
+        let event = serde_json::from_value::<AuditEvent>(value).map_err(|source| {
             SqliteAuditIndexError::ParseNdjsonLine {
                 path: path.to_path_buf(),
                 line: index + 1,
@@ -730,6 +1091,8 @@ mod tests {
         Actor, AuditEvent, AuditEventKind, DefaultMode, ExecutionPlan, ExecutionResult, NetLevel,
         ResolvedProfile, ResourceLimits, Status, WorkspaceMode,
     };
+    use ed25519_dalek::pkcs8::{EncodePrivateKey, EncodePublicKey};
+    use ed25519_dalek::SigningKey;
     use rusqlite::Connection;
     use serde::{Deserialize, Serialize};
 
@@ -751,6 +1114,21 @@ mod tests {
     impl Drop for HashChainGuard {
         fn drop(&mut self) {
             std::env::remove_var("CLAWCRATE_AUDIT_HASHCHAIN");
+        }
+    }
+
+    struct SigningEnvGuard;
+    impl SigningEnvGuard {
+        fn enable(key_path: &Path, block_size: usize) -> Self {
+            std::env::set_var("CLAWCRATE_AUDIT_SIGN", key_path);
+            std::env::set_var("CLAWCRATE_AUDIT_SIGN_BLOCK_SIZE", block_size.to_string());
+            Self
+        }
+    }
+    impl Drop for SigningEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("CLAWCRATE_AUDIT_SIGN");
+            std::env::remove_var("CLAWCRATE_AUDIT_SIGN_BLOCK_SIZE");
         }
     }
 
@@ -1313,6 +1691,18 @@ mod tests {
         }
     }
 
+    fn sample_started_event(pid: u32) -> AuditEvent {
+        AuditEvent {
+            timestamp: chrono::DateTime::parse_from_rfc3339("2026-05-14T10:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            event: AuditEventKind::ProcessStarted {
+                pid,
+                command: vec!["echo".to_string(), "hello".to_string()],
+            },
+        }
+    }
+
     fn write_chained_ndjson(dir: &Path, events: &[AuditEvent]) -> PathBuf {
         use super::{compute_event_hash, AUDIT_NDJSON, GENESIS_HASH};
         use std::io::Write as _;
@@ -1335,6 +1725,22 @@ mod tests {
             prev = current;
         }
         path
+    }
+
+    fn write_test_ed25519_keypair(dir: &Path) -> (PathBuf, PathBuf) {
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let private_pem = signing_key
+            .to_pkcs8_pem(Default::default())
+            .expect("encode private key");
+        let public_pem = signing_key
+            .verifying_key()
+            .to_public_key_pem(Default::default())
+            .expect("encode public key");
+        let private_path = dir.join("audit-signing.key");
+        let public_path = dir.join("audit-signing.pub");
+        fs::write(&private_path, private_pem.as_bytes()).expect("write private key");
+        fs::write(&public_path, public_pem.as_bytes()).expect("write public key");
+        (private_path, public_path)
     }
 
     #[test]
@@ -1388,5 +1794,99 @@ mod tests {
         let result = super::verify_audit_chain(&path).unwrap();
         assert!(!result.valid);
         assert_eq!(result.tampered_at, Some(2));
+    }
+
+    #[test]
+    fn signing_appends_block_signature_and_verify_accepts_pubkey() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let root = unique_tmp_dir("audit_signing_roundtrip");
+        let (private_key, public_key) = write_test_ed25519_keypair(&root);
+        let _guard = SigningEnvGuard::enable(&private_key, 2);
+        let writer = ArtifactWriter::new(&root, "exec-signed").expect("create writer");
+
+        writer.append_audit_event(&sample_started_event(1)).unwrap();
+        writer.append_audit_event(&sample_started_event(2)).unwrap();
+
+        let ndjson = fs::read_to_string(writer.audit_ndjson_path()).expect("read audit");
+        let lines: Vec<serde_json::Value> = ndjson
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("parse audit line"))
+            .collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[2]["kind"], "BlockSignature");
+        assert_eq!(lines[2]["block_start"], 0);
+        assert_eq!(lines[2]["block_end"], 1);
+        assert!(lines[2]["signature"]
+            .as_str()
+            .expect("signature")
+            .starts_with("ed25519:"));
+
+        let result =
+            super::verify_audit_chain_with_pubkey(&writer.audit_ndjson_path(), Some(&public_key))
+                .expect("verify signed audit");
+        assert!(result.valid);
+        assert_eq!(result.events_checked, 2);
+        assert_eq!(result.signatures_checked, 1);
+    }
+
+    #[test]
+    fn signing_flushes_partial_block_on_terminal_event() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let root = unique_tmp_dir("audit_signing_terminal");
+        let (private_key, public_key) = write_test_ed25519_keypair(&root);
+        let _guard = SigningEnvGuard::enable(&private_key, 100);
+        let writer = ArtifactWriter::new(&root, "exec-signed-terminal").expect("create writer");
+
+        writer.append_audit_event(&sample_event()).unwrap();
+
+        let ndjson = fs::read_to_string(writer.audit_ndjson_path()).expect("read audit");
+        let lines: Vec<serde_json::Value> = ndjson
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("parse audit line"))
+            .collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[1]["kind"], "BlockSignature");
+
+        let result =
+            super::verify_audit_chain_with_pubkey(&writer.audit_ndjson_path(), Some(&public_key))
+                .expect("verify signed audit");
+        assert!(result.valid);
+        assert_eq!(result.signatures_checked, 1);
+    }
+
+    #[test]
+    fn verify_fails_when_signed_block_is_modified() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let root = unique_tmp_dir("audit_signing_tamper");
+        let (private_key, public_key) = write_test_ed25519_keypair(&root);
+        let _guard = SigningEnvGuard::enable(&private_key, 2);
+        let writer = ArtifactWriter::new(&root, "exec-signed-tamper").expect("create writer");
+
+        writer.append_audit_event(&sample_started_event(1)).unwrap();
+        writer.append_audit_event(&sample_started_event(2)).unwrap();
+
+        let content = fs::read_to_string(writer.audit_ndjson_path()).expect("read audit");
+        let mut lines: Vec<String> = content.lines().map(ToString::to_string).collect();
+        assert_eq!(lines.len(), 3);
+        let mut signature_line: serde_json::Value =
+            serde_json::from_str(&lines[2]).expect("parse signature line");
+        signature_line["block_hash"] = serde_json::Value::String(super::GENESIS_HASH.to_string());
+        lines[2] = signature_line.to_string();
+        fs::write(
+            writer.audit_ndjson_path(),
+            format!("{}\n", lines.join("\n")),
+        )
+        .expect("write tampered audit");
+
+        let result =
+            super::verify_audit_chain_with_pubkey(&writer.audit_ndjson_path(), Some(&public_key))
+                .expect("verify tampered signed audit");
+        assert!(!result.valid);
+        assert_eq!(result.signatures_checked, 1);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("signature block hash mismatch"));
     }
 }

--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -13,8 +13,8 @@ use anyhow::{anyhow, Result};
 use chrono::Utc;
 use clap::{ArgAction, Args, Parser, Subcommand};
 use clawcrate_audit::{
-    verify_audit_chain, ArtifactWriter, SqliteAuditIndex, VerifyChainError, AUDIT_NDJSON,
-    DEFAULT_AUDIT_DB,
+    verify_audit_chain_with_pubkey, ArtifactWriter, SqliteAuditIndex, VerifyChainError,
+    AUDIT_NDJSON, DEFAULT_AUDIT_DB,
 };
 use clawcrate_capture::{
     capture_streams, diff_snapshots, snapshot_paths, CaptureConfig, CaptureError, CaptureSummary,
@@ -137,6 +137,10 @@ struct DoctorArgs {
 struct VerifyArgs {
     /// Run ID (directory name under ~/.clawcrate/runs/)
     run_id: String,
+
+    /// Ed25519 public key PEM used to validate BlockSignature entries
+    #[arg(long)]
+    pubkey: Option<PathBuf>,
 
     /// Machine-readable JSON output
     #[arg(long, action = ArgAction::SetTrue)]
@@ -2082,7 +2086,7 @@ fn handle_verify(args: VerifyArgs, output: &OutputOptions) -> Result<()> {
     let run_dir = runs_root()?.join(&args.run_id);
     let audit_path = run_dir.join(AUDIT_NDJSON);
 
-    let result = match verify_audit_chain(&audit_path) {
+    let result = match verify_audit_chain_with_pubkey(&audit_path, args.pubkey.as_deref()) {
         Ok(r) => r,
         Err(VerifyChainError::NotFound { .. }) => {
             if args.json {
@@ -2091,6 +2095,7 @@ fn handle_verify(args: VerifyArgs, output: &OutputOptions) -> Result<()> {
                     serde_json::json!({
                         "valid": false,
                         "events_checked": 0,
+                        "signatures_checked": 0,
                         "tampered_at": null,
                         "run_id": args.run_id,
                         "error": format!("run '{}' not found", args.run_id)
@@ -2109,6 +2114,7 @@ fn handle_verify(args: VerifyArgs, output: &OutputOptions) -> Result<()> {
                     serde_json::json!({
                         "valid": false,
                         "events_checked": 0,
+                        "signatures_checked": 0,
                         "tampered_at": null,
                         "run_id": args.run_id,
                         "error": "audit.ndjson has no hash chain (re-run with CLAWCRATE_AUDIT_HASHCHAIN=1)"
@@ -2128,12 +2134,25 @@ fn handle_verify(args: VerifyArgs, output: &OutputOptions) -> Result<()> {
         Err(VerifyChainError::Io(e)) => {
             return Err(anyhow!("failed to read audit.ndjson: {e}"));
         }
+        Err(VerifyChainError::ReadPublicKey { path, source }) => {
+            return Err(anyhow!(
+                "failed to read Ed25519 public key {}: {source}",
+                path.display()
+            ));
+        }
+        Err(VerifyChainError::PublicKey { path, detail }) => {
+            return Err(anyhow!(
+                "failed to parse Ed25519 public key {}: {detail}",
+                path.display()
+            ));
+        }
     };
 
     if args.json {
         let mut obj = serde_json::json!({
             "valid": result.valid,
             "events_checked": result.events_checked,
+            "signatures_checked": result.signatures_checked,
             "tampered_at": result.tampered_at,
             "run_id": args.run_id,
         });
@@ -2154,6 +2173,12 @@ fn handle_verify(args: VerifyArgs, output: &OutputOptions) -> Result<()> {
                 "{check} Hash chain valid ({} events)",
                 result.events_checked
             );
+            if args.pubkey.is_some() {
+                println!(
+                    "{check} Signatures valid ({} block signature(s))",
+                    result.signatures_checked
+                );
+            }
             println!("{check} No tampering detected");
             println!("   Run ID:      {}", args.run_id);
             if let Some(ts) = &result.first_event_ts {


### PR DESCRIPTION
## Summary
- add optional Ed25519 BlockSignature entries via CLAWCRATE_AUDIT_SIGN
- validate signatures with clawcrate verify <run-id> --pubkey <path>
- keep unsigned audit output unchanged and skip signature rows in SQLite indexing

## Validation
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #231