### PR TITLE
feat(cli): export audit logs for SIEM ingestion

### DIFF
--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use chrono::Utc;
-use clap::{ArgAction, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use clawcrate_audit::{
     verify_audit_chain_with_pubkey, ArtifactWriter, SqliteAuditIndex, VerifyChainError,
     AUDIT_NDJSON, DEFAULT_AUDIT_DB,
@@ -97,6 +97,8 @@ enum Commands {
     Bridge(BridgeArgs),
     /// Verify the SHA-256 hash chain of a run's audit log
     Verify(VerifyArgs),
+    /// Audit artifact utilities
+    Audit(AuditArgs),
 }
 
 #[derive(Debug, Args)]
@@ -148,6 +150,40 @@ struct VerifyArgs {
 }
 
 #[derive(Debug, Args)]
+struct AuditArgs {
+    #[command(subcommand)]
+    command: AuditCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum AuditCommand {
+    /// Export audit.ndjson to SIEM-friendly formats
+    Export(AuditExportArgs),
+}
+
+#[derive(Debug, Args)]
+struct AuditExportArgs {
+    /// Run ID (directory name under ~/.clawcrate/runs/)
+    run_id: String,
+
+    /// Export format
+    #[arg(long, value_enum, default_value_t = AuditExportFormat::Json)]
+    format: AuditExportFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum AuditExportFormat {
+    /// ClawCrate native audit.ndjson passthrough
+    Json,
+    /// ArcSight Common Event Format
+    Cef,
+    /// RFC 5424 syslog lines
+    Syslog,
+    /// Elasticsearch/OpenSearch bulk NDJSON
+    Elastic,
+}
+
+#[derive(Debug, Args)]
 struct ApiArgs {
     /// Bind address for local API server
     #[arg(long, default_value = "127.0.0.1:8787")]
@@ -196,6 +232,7 @@ fn run(cli: Cli, output: OutputOptions) -> Result<()> {
         Commands::Api(args) => handle_api(args, &output),
         Commands::Bridge(args) => handle_bridge(args, &output),
         Commands::Verify(args) => handle_verify(args, &output),
+        Commands::Audit(args) => handle_audit(args),
     }
 }
 
@@ -2200,6 +2237,302 @@ fn handle_verify(args: VerifyArgs, output: &OutputOptions) -> Result<()> {
     Ok(())
 }
 
+// ── audit export ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct AuditNdjsonLine {
+    #[serde(flatten)]
+    event: AuditEvent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuditExportSeverity {
+    Low,
+    Medium,
+    High,
+}
+
+impl AuditExportSeverity {
+    fn cef(self) -> u8 {
+        match self {
+            Self::Low => 2,
+            Self::Medium => 5,
+            Self::High => 8,
+        }
+    }
+
+    fn syslog_severity(self) -> u8 {
+        match self {
+            Self::Low => 6,    // informational
+            Self::Medium => 4, // warning
+            Self::High => 3,   // error
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+fn handle_audit(args: AuditArgs) -> Result<()> {
+    match args.command {
+        AuditCommand::Export(args) => handle_audit_export(args),
+    }
+}
+
+fn handle_audit_export(args: AuditExportArgs) -> Result<()> {
+    let audit_path = runs_root()?.join(&args.run_id).join(AUDIT_NDJSON);
+    let content = std::fs::read_to_string(&audit_path)
+        .map_err(|source| anyhow!("failed to read {}: {source}", audit_path.display()))?;
+    let exported = export_audit_content(&args.run_id, &content, args.format)?;
+    print!("{exported}");
+    Ok(())
+}
+
+fn export_audit_content(run_id: &str, content: &str, format: AuditExportFormat) -> Result<String> {
+    if format == AuditExportFormat::Json {
+        return Ok(content.to_string());
+    }
+
+    let events = parse_audit_events_for_export(content)?;
+    match format {
+        AuditExportFormat::Json => unreachable!("json passthrough handled above"),
+        AuditExportFormat::Cef => Ok(events
+            .iter()
+            .map(|event| format_cef_event(run_id, event))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n"),
+        AuditExportFormat::Syslog => Ok(events
+            .iter()
+            .map(|event| format_syslog_event(run_id, event))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n"),
+        AuditExportFormat::Elastic => {
+            let mut out = String::new();
+            for event in &events {
+                out.push_str(&format_elastic_event(run_id, event)?);
+            }
+            Ok(out)
+        }
+    }
+}
+
+fn parse_audit_events_for_export(content: &str) -> Result<Vec<AuditEvent>> {
+    let mut events = Vec::new();
+    for (index, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line).map_err(|source| {
+            anyhow!("failed to parse audit.ndjson line {}: {source}", index + 1)
+        })?;
+        if value
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|kind| kind == "BlockSignature")
+        {
+            continue;
+        }
+        let event = serde_json::from_value::<AuditNdjsonLine>(value)
+            .map_err(|source| anyhow!("failed to parse audit event line {}: {source}", index + 1))?
+            .event;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+fn audit_event_export_metadata(
+    event: &AuditEventKind,
+) -> (&'static str, &'static str, AuditExportSeverity) {
+    match event {
+        AuditEventKind::SandboxApplied { .. } => {
+            ("sandbox_applied", "sandbox", AuditExportSeverity::Low)
+        }
+        AuditEventKind::EnvScrubbed { .. } => {
+            ("env_scrubbed", "environment", AuditExportSeverity::Medium)
+        }
+        AuditEventKind::ProcessStarted { .. } => {
+            ("process_started", "process", AuditExportSeverity::Low)
+        }
+        AuditEventKind::ProcessExited { exit_code, .. } if *exit_code == 0 => {
+            ("process_exited", "process", AuditExportSeverity::Low)
+        }
+        AuditEventKind::ProcessExited { .. } => {
+            ("process_exited", "process", AuditExportSeverity::Medium)
+        }
+        AuditEventKind::PermissionBlocked { .. } => {
+            ("permission_blocked", "security", AuditExportSeverity::High)
+        }
+        AuditEventKind::ReplicaCreated { .. } => {
+            ("replica_created", "workspace", AuditExportSeverity::Low)
+        }
+        AuditEventKind::ReplicaSyncBack { approved, .. } if *approved => (
+            "replica_sync_back",
+            "workspace",
+            AuditExportSeverity::Medium,
+        ),
+        AuditEventKind::ReplicaSyncBack { .. } => {
+            ("replica_sync_back", "workspace", AuditExportSeverity::Low)
+        }
+        AuditEventKind::ApprovalDecision { approved, .. } if *approved => {
+            ("approval_decision", "approval", AuditExportSeverity::Medium)
+        }
+        AuditEventKind::ApprovalDecision { .. } => {
+            ("approval_decision", "approval", AuditExportSeverity::High)
+        }
+    }
+}
+
+fn audit_event_message(event: &AuditEventKind) -> String {
+    match event {
+        AuditEventKind::SandboxApplied {
+            backend,
+            capabilities,
+        } => format!(
+            "sandbox applied using {backend} with {} capabilities",
+            capabilities.len()
+        ),
+        AuditEventKind::EnvScrubbed { removed } => {
+            format!("scrubbed {} environment variable(s)", removed.len())
+        }
+        AuditEventKind::ProcessStarted { pid, command } => {
+            format!("process started pid={pid} command={}", command.join(" "))
+        }
+        AuditEventKind::ProcessExited {
+            exit_code,
+            duration_ms,
+        } => format!("process exited code={exit_code} duration_ms={duration_ms}"),
+        AuditEventKind::PermissionBlocked { resource, reason } => {
+            format!("permission blocked resource={resource} reason={reason}")
+        }
+        AuditEventKind::ReplicaCreated {
+            source,
+            copy,
+            excluded,
+        } => format!(
+            "replica created source={} copy={} excluded={}",
+            source.display(),
+            copy.display(),
+            excluded.len()
+        ),
+        AuditEventKind::ReplicaSyncBack { approved, changes } => {
+            format!("replica sync-back approved={approved} changes={changes}")
+        }
+        AuditEventKind::ApprovalDecision {
+            requested,
+            approved,
+            automated,
+        } => format!(
+            "approval decision approved={approved} automated={automated} requested={}",
+            requested.len()
+        ),
+    }
+}
+
+fn format_cef_event(run_id: &str, event: &AuditEvent) -> String {
+    let (signature_id, category, severity) = audit_event_export_metadata(&event.event);
+    let message = audit_event_message(&event.event);
+    format!(
+        "CEF:0|ClawCrate|clawcrate|{}|{}|{}|{}|rt={} cs1Label=run_id cs1={} cs2Label=category cs2={} msg={}",
+        env!("CARGO_PKG_VERSION"),
+        escape_cef_header(signature_id),
+        escape_cef_header(signature_id),
+        severity.cef(),
+        event.timestamp.to_rfc3339(),
+        escape_cef_extension(run_id),
+        escape_cef_extension(category),
+        escape_cef_extension(&message)
+    )
+}
+
+fn format_syslog_event(run_id: &str, event: &AuditEvent) -> String {
+    let (event_name, category, severity) = audit_event_export_metadata(&event.event);
+    let pri = 8 + severity.syslog_severity(); // facility=user(1) * 8 + severity
+    let message = audit_event_message(&event.event);
+    format!(
+        "<{pri}>1 {} - clawcrate {} {} [clawcrate@54531 run_id=\"{}\" category=\"{}\" severity=\"{}\"] {}",
+        event.timestamp.to_rfc3339(),
+        sanitize_syslog_token(run_id),
+        sanitize_syslog_token(event_name),
+        escape_syslog_param(run_id),
+        escape_syslog_param(category),
+        severity.label(),
+        sanitize_syslog_message(&message)
+    )
+}
+
+fn format_elastic_event(run_id: &str, event: &AuditEvent) -> Result<String> {
+    let (event_name, category, severity) = audit_event_export_metadata(&event.event);
+    let action = serde_json::json!({
+        "index": {
+            "_index": "clawcrate-audit",
+        }
+    });
+    let source = serde_json::json!({
+        "@timestamp": event.timestamp,
+        "run_id": run_id,
+        "event": {
+            "kind": event_name,
+            "category": category,
+            "severity": severity.label(),
+        },
+        "message": audit_event_message(&event.event),
+        "clawcrate": event,
+    });
+    Ok(format!(
+        "{}\n{}\n",
+        serde_json::to_string(&action)?,
+        serde_json::to_string(&source)?
+    ))
+}
+
+fn escape_cef_header(value: &str) -> String {
+    value
+        .replace('\\', r"\\")
+        .replace('|', r"\|")
+        .replace('\n', r"\n")
+        .replace('\r', r"\r")
+}
+
+fn escape_cef_extension(value: &str) -> String {
+    value
+        .replace('\\', r"\\")
+        .replace('=', r"\=")
+        .replace('\n', r"\n")
+        .replace('\r', r"\r")
+}
+
+fn sanitize_syslog_token(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .filter(|ch| ch.is_ascii_graphic() && *ch != ']' && *ch != '"')
+        .take(48)
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "-".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn escape_syslog_param(value: &str) -> String {
+    value
+        .replace('\\', r"\\")
+        .replace('"', r#"\""#)
+        .replace(']', r"\]")
+}
+
+fn sanitize_syslog_message(value: &str) -> String {
+    value.replace(['\n', '\r'], " ")
+}
+
 // ── api ───────────────────────────────────────────────────────────────────────
 
 const API_MAX_WORKERS: usize = 4;
@@ -2945,9 +3278,9 @@ mod tests {
         materialize_workspace_for_execution, request_authorized, resolve_api_route,
         resolve_execution_path, run_monitored_child, run_monitored_child_with_signal_poller,
         select_default_mode, serialize_api_payload, should_exclude_default_replica_path,
-        should_use_color, ApiCommandRequest, ApiRoute, BoundedWorkQueue, BridgeTarget, Cli,
-        CommandArgs, Commands, PennyPromptBridgeRequest, QueueEnqueueError, ReplicaSyncChange,
-        RunTermination,
+        should_use_color, ApiCommandRequest, ApiRoute, AuditCommand, AuditExportFormat,
+        BoundedWorkQueue, BridgeTarget, Cli, CommandArgs, Commands, PennyPromptBridgeRequest,
+        QueueEnqueueError, ReplicaSyncChange, RunTermination,
     };
     #[cfg(unix)]
     use super::{eligible_process_group_id, send_unix_signal_with_group_fallback_impl};
@@ -3069,6 +3402,28 @@ mod tests {
     }
 
     #[test]
+    fn parses_audit_export_command_with_format() {
+        let cli = Cli::parse_from([
+            "clawcrate",
+            "audit",
+            "export",
+            "exec-123",
+            "--format",
+            "elastic",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => match args.command {
+                AuditCommand::Export(config) => {
+                    assert_eq!(config.run_id, "exec-123");
+                    assert_eq!(config.format, AuditExportFormat::Elastic);
+                }
+            },
+            _ => panic!("expected audit export command"),
+        }
+    }
+
+    #[test]
     fn parses_global_verbose_and_no_color_flags() {
         let cli = Cli::parse_from([
             "clawcrate",
@@ -3089,6 +3444,106 @@ mod tests {
         assert!(!should_use_color(false, true, true));
         assert!(!should_use_color(false, false, false));
         assert!(should_use_color(false, false, true));
+    }
+
+    fn sample_audit_export_content() -> String {
+        let ts = chrono::DateTime::parse_from_rfc3339("2026-05-14T22:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let started = AuditEvent {
+            timestamp: ts,
+            event: AuditEventKind::ProcessStarted {
+                pid: 42,
+                command: vec!["cat".to_string(), ".env".to_string()],
+            },
+        };
+        let blocked = AuditEvent {
+            timestamp: ts,
+            event: AuditEventKind::PermissionBlocked {
+                resource: "/workspace/.env".to_string(),
+                reason: "profile denied read".to_string(),
+            },
+        };
+        format!(
+            "{}\n{}\n{}\n",
+            serde_json::to_string(&started).unwrap(),
+            serde_json::json!({
+                "kind": "BlockSignature",
+                "block_start": 0,
+                "block_end": 1,
+                "block_hash": "sha256:abc",
+                "signature": "ed25519:def",
+                "public_key_fingerprint": "SHA256:key",
+            }),
+            serde_json::to_string(&blocked).unwrap()
+        )
+    }
+
+    #[test]
+    fn audit_export_json_is_native_passthrough() {
+        let content = sample_audit_export_content();
+        let exported =
+            super::export_audit_content("exec-export", &content, AuditExportFormat::Json)
+                .expect("export json");
+        assert_eq!(exported, content);
+    }
+
+    #[test]
+    fn audit_export_cef_maps_events_and_high_severity() {
+        let exported = super::export_audit_content(
+            "exec-export",
+            &sample_audit_export_content(),
+            AuditExportFormat::Cef,
+        )
+        .expect("export cef");
+        let lines = exported.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 2, "BlockSignature rows are not audit events");
+        assert!(lines[0].starts_with("CEF:0|ClawCrate|clawcrate|"));
+        assert!(lines[0].contains("|process_started|process_started|2|"));
+        assert!(lines[1].contains("|permission_blocked|permission_blocked|8|"));
+        assert!(lines[1].contains("cs1=exec-export"));
+        assert!(lines[1].contains("cs2=security"));
+    }
+
+    #[test]
+    fn audit_export_syslog_emits_rfc5424_like_lines() {
+        let exported = super::export_audit_content(
+            "exec-export",
+            &sample_audit_export_content(),
+            AuditExportFormat::Syslog,
+        )
+        .expect("export syslog");
+        let lines = exported.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with(
+            "<14>1 2026-05-14T22:00:00+00:00 - clawcrate exec-export process_started "
+        ));
+        assert!(lines[1].starts_with(
+            "<11>1 2026-05-14T22:00:00+00:00 - clawcrate exec-export permission_blocked "
+        ));
+        assert!(lines[1].contains("severity=\"high\""));
+    }
+
+    #[test]
+    fn audit_export_elastic_emits_bulk_ndjson_pairs() {
+        let exported = super::export_audit_content(
+            "exec-export",
+            &sample_audit_export_content(),
+            AuditExportFormat::Elastic,
+        )
+        .expect("export elastic");
+        let lines = exported.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 4);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(lines[0]).unwrap()["index"]["_index"],
+            "clawcrate-audit"
+        );
+        let first_doc = serde_json::from_str::<serde_json::Value>(lines[1]).unwrap();
+        assert_eq!(first_doc["run_id"], "exec-export");
+        assert_eq!(first_doc["event"]["kind"], "process_started");
+        let second_doc = serde_json::from_str::<serde_json::Value>(lines[3]).unwrap();
+        assert_eq!(second_doc["event"]["severity"], "high");
+        assert_eq!(second_doc["event"]["category"], "security");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add clawcrate audit export <run-id> with json, cef, syslog, and elastic formats
- map AuditEventKind variants to SIEM categories and low/medium/high severity
- preserve native audit.ndjson for json passthrough and skip BlockSignature rows for event-oriented SIEM exports

## Validation
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p clawcrate-cli audit_export

Closes #232