### PR TITLE
bench(audit): measure hash chain overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Cargo check
         run: cargo check --workspace
 
+      - name: Audit benchmark compile (informational)
+        run: cargo bench -p clawcrate-audit --no-run
+        continue-on-error: true
+
   integration-and-fixtures:
     name: Integration + Fixtures (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +196,33 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -232,6 +271,7 @@ dependencies = [
  "base64",
  "chrono",
  "clawcrate-types",
+ "criterion",
  "ed25519-dalek",
  "rusqlite",
  "serde",
@@ -344,6 +384,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +466,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -481,6 +563,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -576,6 +664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +712,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "httpdate"
@@ -679,10 +784,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -790,6 +915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +969,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,12 +1040,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1158,6 +1349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1534,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/clawcrate-audit/Cargo.toml
+++ b/crates/clawcrate-audit/Cargo.toml
@@ -19,3 +19,10 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "2"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "hash_chain"
+harness = false

--- a/crates/clawcrate-audit/benches/hash_chain.rs
+++ b/crates/clawcrate-audit/benches/hash_chain.rs
@@ -1,0 +1,122 @@
+#![forbid(unsafe_code)]
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::Utc;
+use clawcrate_audit::{
+    compute_event_hash, verify_audit_chain, ArtifactWriter, AUDIT_NDJSON, GENESIS_HASH,
+};
+use clawcrate_types::{AuditEvent, AuditEventKind};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+fn sample_event(index: u32) -> AuditEvent {
+    AuditEvent {
+        timestamp: chrono::DateTime::parse_from_rfc3339("2026-05-15T02:00:00Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc),
+        event: AuditEventKind::ProcessStarted {
+            pid: 10_000 + index,
+            command: vec![
+                "cargo".to_string(),
+                "test".to_string(),
+                "--workspace".to_string(),
+            ],
+        },
+    }
+}
+
+fn bench_hash_chain_compute(c: &mut Criterion) {
+    let event = sample_event(1);
+    c.bench_function("hash_chain_compute_single_event", |b| {
+        b.iter(|| compute_event_hash(black_box(&event), black_box(GENESIS_HASH)))
+    });
+}
+
+fn bench_hash_chain_append(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_chain_append");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("single_event_new_file", |b| {
+        b.iter_batched(
+            || {
+                let root = unique_tmp_dir("clawcrate_bench_append");
+                let writer = ArtifactWriter::new(&root, "exec-bench").expect("create writer");
+                let event = sample_event(1);
+                (root, writer, event)
+            },
+            |(root, writer, event)| {
+                with_hash_chain_enabled(|| writer.append_audit_event(black_box(&event)))
+                    .expect("append audit event");
+                fs::remove_dir_all(root).ok();
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_verify_throughput(c: &mut Criterion) {
+    let events = 10_000usize;
+    let root = unique_tmp_dir("clawcrate_bench_verify");
+    let audit_path = generate_chained_audit_log(&root, events);
+
+    let mut group = c.benchmark_group("verify_hash_chain");
+    group.throughput(Throughput::Elements(events as u64));
+    group.bench_with_input(
+        BenchmarkId::from_parameter(format!("{events}_events")),
+        &audit_path,
+        |b, path| {
+            b.iter(|| {
+                let result = verify_audit_chain(black_box(path)).expect("verify chain");
+                assert!(result.valid);
+                black_box(result.events_checked);
+            })
+        },
+    );
+    group.finish();
+
+    fs::remove_dir_all(root).ok();
+}
+
+fn generate_chained_audit_log(root: &Path, events: usize) -> PathBuf {
+    let writer = ArtifactWriter::new(root, "exec-verify-bench").expect("create writer");
+    with_hash_chain_enabled(|| {
+        for index in 0..events {
+            writer
+                .append_audit_event(&sample_event(index as u32))
+                .expect("append chained event");
+        }
+    });
+    writer.artifacts_dir().join(AUDIT_NDJSON)
+}
+
+fn with_hash_chain_enabled<T>(f: impl FnOnce() -> T) -> T {
+    let previous = std::env::var_os("CLAWCRATE_AUDIT_HASHCHAIN");
+    std::env::set_var("CLAWCRATE_AUDIT_HASHCHAIN", "1");
+    let result = f();
+    match previous {
+        Some(value) => std::env::set_var("CLAWCRATE_AUDIT_HASHCHAIN", value),
+        None => std::env::remove_var("CLAWCRATE_AUDIT_HASHCHAIN"),
+    }
+    result
+}
+
+fn unique_tmp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("{prefix}_{nanos}_{}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp benchmark directory");
+    dir
+}
+
+criterion_group!(
+    benches,
+    bench_hash_chain_compute,
+    bench_hash_chain_append,
+    bench_verify_throughput
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add Criterion benchmarks for audit hash-chain compute, append reference, and 10k-event verify throughput
- add cargo bench -p clawcrate-audit --no-run to CI as an informational, non-blocking compile step
- lock Criterion dependencies for reproducible local and CI benchmark compilation

## Local benchmark snapshot
Command:

```bash
cargo bench -p clawcrate-audit --bench hash_chain -- --sample-size 10 --measurement-time 1
```

Results on this machine:
- hash_chain_compute_single_event: 1.94-2.15 us/event, median about 2.04 us. This is below the <100 us/event target.
- verify_hash_chain/10000_events: 29.8-33.7 ms for 10k events, about 316k events/sec.
- hash_chain_append/single_event_new_file: 297-307 us/event. This includes filesystem setup/write/flush/remove and is retained as an I/O reference, not the pure hash-chain target metric.

## Validation
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo bench -p clawcrate-audit --no-run
- cargo bench -p clawcrate-audit --bench hash_chain -- --sample-size 10 --measurement-time 1

Closes #235