### PR TITLE
feat(profiles): add mcp-server community profile

### DIFF
--- a/crates/clawcrate-profiles/src/lib.rs
+++ b/crates/clawcrate-profiles/src/lib.rs
@@ -944,6 +944,30 @@ network:
     }
 
     #[test]
+    fn resolves_mcp_server_community_profile_with_secret_guardrails() {
+        let resolver = ProfileResolver::default();
+        let profile_path = resolver
+            .profiles_dir()
+            .join("community")
+            .join("mcp-server.yaml");
+
+        let profile = resolver
+            .resolve_from_path(&profile_path)
+            .expect("resolve mcp-server community profile");
+
+        assert_eq!(profile.name, "mcp-server");
+        assert_eq!(profile.default_mode, DefaultMode::Replica);
+        assert_eq!(profile.net, NetLevel::None);
+        assert!(profile.fs_read.iter().any(|it| it == Path::new(".")));
+        assert!(profile.fs_write.iter().any(|it| it == Path::new(".")));
+        assert!(profile.fs_deny.iter().any(|it| it == ".env"));
+        assert!(profile.fs_deny.iter().any(|it| it == "**/.env.*"));
+        assert!(profile.fs_deny.iter().any(|it| it == ".git/config"));
+        assert!(profile.env_scrub.iter().any(|it| it == "SSH_AUTH_SOCK"));
+        assert!(profile.env_scrub.iter().any(|it| it == "*_TOKEN*"));
+    }
+
+    #[test]
     fn rejects_catalog_entry_with_parent_directory_escape() {
         let resolver = ProfileResolver::default();
         let tmp = unique_tmp_dir("clawcrate_profiles_catalog_path_escape");

--- a/docs/community-profiles.md
+++ b/docs/community-profiles.md
@@ -9,6 +9,8 @@ Community profiles live under `profiles/community/`:
 ```text
 profiles/community/
 ├── catalog.yaml
+├── agent-inference-allowlist.yaml
+├── mcp-server.yaml
 ├── npm-install-allowlist.yaml
 └── pip-install-pypi-only.yaml
 ```
@@ -70,3 +72,14 @@ Maintainers should verify:
 - replica/direct default is aligned with risk level
 - env scrub/pass-through values avoid secret leakage
 - profile naming and metadata in catalog remain clear and searchable
+
+## MCP Server Profile
+
+`mcp-server` is a community profile for stdio MCP servers that need read/write
+access to the project workspace but should not read local secrets or reach the
+network.
+
+The profile defaults to Replica mode because Linux Landlock cannot reliably deny
+specific secret files inside an otherwise allowed workspace path. Replica mode
+keeps that promise by filtering the materialized workspace before launch, while
+macOS also applies Seatbelt deny rules for the same sensitive path patterns.

--- a/profiles/community/catalog.yaml
+++ b/profiles/community/catalog.yaml
@@ -26,3 +26,12 @@ profiles:
       - filtered-network
       - anthropic
       - openai
+  - id: mcp-server
+    title: MCP server workspace profile (read/write workspace, no secrets, no network)
+    path: mcp-server.yaml
+    owner: "@clawcrate-community"
+    tags:
+      - mcp
+      - agent
+      - replica
+      - no-network

--- a/profiles/community/mcp-server.yaml
+++ b/profiles/community/mcp-server.yaml
@@ -1,0 +1,57 @@
+name: mcp-server
+default_mode: Replica
+
+filesystem:
+  read:
+    - "."
+  write:
+    - "."
+  deny:
+    - ".env"
+    - ".env.*"
+    - "**/.env"
+    - "**/.env.*"
+    - ".git/config"
+    - "**/.git/config"
+    - ".npmrc"
+    - "**/.npmrc"
+    - ".pypirc"
+    - "**/.pypirc"
+    - ".netrc"
+    - "**/.netrc"
+
+network: none
+
+environment:
+  scrub:
+    - "AWS_*"
+    - "AZURE_*"
+    - "GCP_*"
+    - "GOOGLE_APPLICATION_CREDENTIALS"
+    - "ANTHROPIC_API_KEY"
+    - "OPENAI_API_KEY"
+    - "GITHUB_TOKEN"
+    - "NPM_TOKEN"
+    - "DATABASE_URL"
+    - "SSH_AUTH_SOCK"
+    - "*_SECRET*"
+    - "*_PASSWORD*"
+    - "*_TOKEN*"
+    - "*_KEY"
+  passthrough:
+    - "HOME"
+    - "PATH"
+    - "USER"
+    - "SHELL"
+    - "TERM"
+    - "LANG"
+    - "LC_*"
+    - "TMPDIR"
+    - "XDG_*"
+
+resources:
+  max_cpu_seconds: 600
+  max_memory_mb: 2048
+  max_open_files: 1024
+  max_processes: 128
+  max_output_bytes: 8388608


### PR DESCRIPTION
## Summary\n\n- Add profiles/community/mcp-server.yaml for generic MCP servers with read/write workspace access.\n- Default the profile to Replica mode so Linux does not promise intra-workspace secret denies it cannot enforce directly.\n- Block network, scrub common secret-bearing env vars, add catalog/docs coverage, and test profile resolution guardrails.\n\n## Validation\n\n- cargo fmt --all -- --check\n- cargo test --workspace\n- cargo clippy --workspace --all-targets -- -D warnings\n\nCloses #249