### PR TITLE
feat(profiles): add mcp-readonly community profile

### DIFF
--- a/crates/clawcrate-profiles/src/lib.rs
+++ b/crates/clawcrate-profiles/src/lib.rs
@@ -968,6 +968,30 @@ network:
     }
 
     #[test]
+    fn resolves_mcp_readonly_community_profile_without_write_access() {
+        let resolver = ProfileResolver::default();
+        let profile_path = resolver
+            .profiles_dir()
+            .join("community")
+            .join("mcp-readonly.yaml");
+
+        let profile = resolver
+            .resolve_from_path(&profile_path)
+            .expect("resolve mcp-readonly community profile");
+
+        assert_eq!(profile.name, "mcp-readonly");
+        assert_eq!(profile.default_mode, DefaultMode::Replica);
+        assert_eq!(profile.net, NetLevel::None);
+        assert!(profile.fs_read.iter().any(|it| it == Path::new(".")));
+        assert!(profile.fs_write.is_empty());
+        assert!(profile.fs_deny.iter().any(|it| it == ".env"));
+        assert!(profile.fs_deny.iter().any(|it| it == "**/.env.*"));
+        assert!(profile.fs_deny.iter().any(|it| it == ".git/config"));
+        assert!(profile.env_scrub.iter().any(|it| it == "SSH_AUTH_SOCK"));
+        assert!(profile.env_scrub.iter().any(|it| it == "*_TOKEN*"));
+    }
+
+    #[test]
     fn rejects_catalog_entry_with_parent_directory_escape() {
         let resolver = ProfileResolver::default();
         let tmp = unique_tmp_dir("clawcrate_profiles_catalog_path_escape");

--- a/docs/community-profiles.md
+++ b/docs/community-profiles.md
@@ -10,6 +10,7 @@ Community profiles live under `profiles/community/`:
 profiles/community/
 ├── catalog.yaml
 ├── agent-inference-allowlist.yaml
+├── mcp-readonly.yaml
 ├── mcp-server.yaml
 ├── npm-install-allowlist.yaml
 └── pip-install-pypi-only.yaml
@@ -83,3 +84,8 @@ The profile defaults to Replica mode because Linux Landlock cannot reliably deny
 specific secret files inside an otherwise allowed workspace path. Replica mode
 keeps that promise by filtering the materialized workspace before launch, while
 macOS also applies Seatbelt deny rules for the same sensitive path patterns.
+
+`mcp-readonly` is the stricter companion profile for MCP servers that only need
+to inspect project files. It grants workspace reads, grants no write paths,
+blocks network access, and uses the same Replica-mode secret filtering rationale
+as `mcp-server`.

--- a/profiles/community/catalog.yaml
+++ b/profiles/community/catalog.yaml
@@ -35,3 +35,13 @@ profiles:
       - agent
       - replica
       - no-network
+  - id: mcp-readonly
+    title: MCP server read-only workspace profile (no writes, no secrets, no network)
+    path: mcp-readonly.yaml
+    owner: "@clawcrate-community"
+    tags:
+      - mcp
+      - agent
+      - read-only
+      - replica
+      - no-network

--- a/profiles/community/mcp-readonly.yaml
+++ b/profiles/community/mcp-readonly.yaml
@@ -1,0 +1,56 @@
+name: mcp-readonly
+default_mode: Replica
+
+filesystem:
+  read:
+    - "."
+  write: []
+  deny:
+    - ".env"
+    - ".env.*"
+    - "**/.env"
+    - "**/.env.*"
+    - ".git/config"
+    - "**/.git/config"
+    - ".npmrc"
+    - "**/.npmrc"
+    - ".pypirc"
+    - "**/.pypirc"
+    - ".netrc"
+    - "**/.netrc"
+
+network: none
+
+environment:
+  scrub:
+    - "AWS_*"
+    - "AZURE_*"
+    - "GCP_*"
+    - "GOOGLE_APPLICATION_CREDENTIALS"
+    - "ANTHROPIC_API_KEY"
+    - "OPENAI_API_KEY"
+    - "GITHUB_TOKEN"
+    - "NPM_TOKEN"
+    - "DATABASE_URL"
+    - "SSH_AUTH_SOCK"
+    - "*_SECRET*"
+    - "*_PASSWORD*"
+    - "*_TOKEN*"
+    - "*_KEY"
+  passthrough:
+    - "HOME"
+    - "PATH"
+    - "USER"
+    - "SHELL"
+    - "TERM"
+    - "LANG"
+    - "LC_*"
+    - "TMPDIR"
+    - "XDG_*"
+
+resources:
+  max_cpu_seconds: 600
+  max_memory_mb: 2048
+  max_open_files: 1024
+  max_processes: 128
+  max_output_bytes: 8388608


### PR DESCRIPTION
## Summary

- Add profiles/community/mcp-readonly.yaml for MCP servers that only need to inspect project files.
- Default to Replica mode, block network, grant no write paths, and scrub common secret-bearing env vars.
- Add catalog/docs coverage and a resolver test that asserts read-only guardrails.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #251