### PR TITLE
fix(replica): canonicalize macOS temp workspace paths

### DIFF
--- a/crates/clawcrate-cli/src/main.rs
+++ b/crates/clawcrate-cli/src/main.rs
@@ -2740,12 +2740,17 @@ fn materialize_workspace_mode(
         DefaultMode::Direct => WorkspaceMode::Direct,
         DefaultMode::Replica => WorkspaceMode::Replica {
             source: source_cwd.to_path_buf(),
-            copy: std::env::temp_dir()
+            copy: replica_temp_root()
                 .join("clawcrate")
                 .join(format!("exec_{execution_id}"))
                 .join("workspace"),
         },
     }
+}
+
+fn replica_temp_root() -> PathBuf {
+    let temp_root = std::env::temp_dir();
+    std::fs::canonicalize(&temp_root).unwrap_or(temp_root)
 }
 
 fn handle_doctor(args: DoctorArgs, output: &OutputOptions) -> Result<()> {
@@ -4035,8 +4040,8 @@ mod tests {
         detect_stdio_mcp_server_shape, doctor_rows, execution_status,
         execution_status_from_exit_status, extract_bearer_token, extract_host_from_reference,
         is_replica_sync_back_interactive, load_replica_ignore_config,
-        materialize_workspace_for_execution, relay_stream_to_output_and_log, request_authorized,
-        resolve_api_route, resolve_execution_path, run_monitored_child,
+        materialize_workspace_for_execution, relay_stream_to_output_and_log, replica_temp_root,
+        request_authorized, resolve_api_route, resolve_execution_path, run_monitored_child,
         run_monitored_child_with_signal_poller, select_default_mode, serialize_api_payload,
         should_exclude_default_replica_path, should_use_color, ApiCommandRequest, ApiRoute,
         AuditCommand, AuditExportFormat, BoundedWorkQueue, BridgeTarget, Cli, CommandArgs,
@@ -5174,7 +5179,7 @@ mod tests {
         match &plan.mode {
             WorkspaceMode::Replica { source, copy } => {
                 assert_eq!(source, &cwd);
-                assert!(copy.starts_with(Path::new(&std::env::temp_dir())));
+                assert!(copy.starts_with(replica_temp_root()));
                 assert_eq!(plan.cwd, *copy);
             }
             WorkspaceMode::Direct => panic!("install profile must default to replica"),
@@ -5228,7 +5233,7 @@ mod tests {
         match &plan.mode {
             WorkspaceMode::Replica { source, copy } => {
                 assert_eq!(source, &cwd);
-                assert!(copy.starts_with(Path::new(&std::env::temp_dir())));
+                assert!(copy.starts_with(replica_temp_root()));
                 assert_eq!(plan.cwd, *copy);
             }
             WorkspaceMode::Direct => {

--- a/crates/clawcrate-cli/tests/install_replica_integration.rs
+++ b/crates/clawcrate-cli/tests/install_replica_integration.rs
@@ -150,3 +150,52 @@ fn install_run_uses_replica_and_excludes_secret_env_files() {
         "replica copy should contain non-secret files"
     );
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn readonly_replica_run_can_read_its_canonical_workspace() {
+    let workspace = unique_tmp_dir("clawcrate_cli_it_readonly_replica_workspace");
+    let home = unique_tmp_dir("clawcrate_cli_it_readonly_replica_home");
+    fs::write(workspace.join("public.txt"), "visible").expect("write public file");
+
+    let summary = run_clawcrate_json(
+        &[
+            "run",
+            "--profile",
+            "mcp-readonly",
+            "--json",
+            "--",
+            "/bin/sh",
+            "-c",
+            "test -f public.txt",
+        ],
+        &workspace,
+        &home,
+    );
+
+    let artifacts_dir = PathBuf::from(
+        summary
+            .get("result")
+            .and_then(|result| result.get("artifacts_dir"))
+            .and_then(Value::as_str)
+            .expect("artifacts_dir in run summary"),
+    );
+    let plan: Value = serde_json::from_str(
+        &fs::read_to_string(artifacts_dir.join("plan.json")).expect("read plan artifact json"),
+    )
+    .expect("parse plan artifact json");
+    let copy_path = PathBuf::from(
+        plan.get("mode")
+            .and_then(|mode| mode.get("Replica"))
+            .and_then(|replica| replica.get("copy"))
+            .and_then(Value::as_str)
+            .expect("replica copy path"),
+    );
+
+    assert!(
+        copy_path.starts_with(
+            fs::canonicalize(std::env::temp_dir()).expect("canonicalize system temp directory")
+        ),
+        "Replica copy should use the physical macOS temp path"
+    );
+}


### PR DESCRIPTION
## Summary

- canonicalize the system temp root before constructing Replica workspace paths
- preserve the previous lexical temp path as a fallback when canonicalization is unavailable
- update Replica plan assertions to use the physical temp root
- add a macOS regression test proving `mcp-readonly` can read its materialized workspace

## Why

On macOS, `std::env::temp_dir()` commonly returns `/var/folders/...`, while the
physical path evaluated by Seatbelt is `/private/var/folders/...`. ClawCrate
generated allow rules for the lexical path, so read-only Replica profiles could
fail to read their own cwd with `Operation not permitted` or Node `uv_cwd`
errors.

This blocked the runnable MCP filesystem demo in #259 and could affect other
read-only Replica executions.

## Impact

Replica execution plans, normalized profile paths, and Seatbelt now refer to the
same physical temp location. Direct mode and Replica filtering/sync semantics
are unchanged.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- macOS regression: `readonly_replica_run_can_read_its_canonical_workspace`

Closes #266
